### PR TITLE
#84 - Implement deleting by chart name

### DIFF
--- a/src/main/java/com/artipie/helm/PushChartSlice.java
+++ b/src/main/java/com/artipie/helm/PushChartSlice.java
@@ -26,6 +26,7 @@ package com.artipie.helm;
 
 import com.artipie.asto.Remaining;
 import com.artipie.asto.Storage;
+import com.artipie.helm.metadata.IndexYaml;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;

--- a/src/main/java/com/artipie/helm/TgzArchive.java
+++ b/src/main/java/com/artipie/helm/TgzArchive.java
@@ -57,7 +57,7 @@ import org.reactivestreams.Subscriber;
     "PMD.AvoidBranchingStatementAsLastInLoop",
     "PMD.AssignmentInOperand"
 })
-final class TgzArchive implements Content {
+public final class TgzArchive implements Content {
 
     /**
      * The eight kb.
@@ -91,7 +91,7 @@ final class TgzArchive implements Content {
      */
     public String name() {
         final ChartYaml chart = this.chartYaml();
-        return String.format("%s-%s.tgz", chart.field("name"), chart.field("version"));
+        return String.format("%s-%s.tgz", chart.name(), chart.version());
     }
 
     /**

--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -156,17 +156,9 @@ public final class IndexYaml {
                     }
                     return result;
                 }
-            ).doOnError(
-                throwable -> {
-                    throw new IllegalStateException(throwable);
-                }
-            ).map(
-                idx -> {
-                    new IndexYamlMapping(idx).entries().remove(name);
-                    return idx;
-                }
             ).flatMapCompletable(
                 idx -> {
+                    new IndexYamlMapping(idx).entries().remove(name);
                     final DumperOptions options = new DumperOptions();
                     options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
                     options.setPrettyFlow(true);

--- a/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
@@ -21,62 +21,55 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package com.artipie.helm;
+package com.artipie.helm.metadata;
 
-import io.reactivex.Single;
+import java.util.List;
 import java.util.Map;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * The Chart.yaml file.
+ * Mapping for content from index.yaml file.
  *
  * @since 0.2
  */
-public class ChartYaml {
+@SuppressWarnings("unchecked")
+public final class IndexYamlMapping {
 
     /**
-     * The Yaml.
+     * Mapping for fields from index.yaml file.
      */
-    private final Single<Map<String, Object>> yaml;
+    private final Map<String, Object> mapping;
 
     /**
      * Ctor.
-     * @param yaml The yaml.
+     * @param yaml Index.yaml file
      */
-    public ChartYaml(final String yaml) {
-        this.yaml = Single.<Map<String, Object>>fromCallable(() -> new Yaml().load(yaml)).cache();
+    public IndexYamlMapping(final String yaml) {
+        this((Map<String, Object>) new Yaml().load(yaml));
     }
 
     /**
-     * Obtain a name of the chart.
-     * @return Name of the chart.
+     * Ctor.
+     * @param mapfromindex Mapping for fields from index.yaml file
      */
-    public String name() {
-        return (String) this.field("name");
+    public IndexYamlMapping(final Map<String, Object> mapfromindex) {
+        this.mapping = mapfromindex;
     }
 
     /**
-     * Obtain a version of the chart.
-     * @return Version of the chart.
+     * Obtain mapping for `entries`.
+     * @return Mapping for `entries`.
      */
-    public String version() {
-        return (String) this.field("version");
+    public Map<String, Object> entries() {
+        return (Map<String, Object>) this.mapping.get("entries");
     }
 
     /**
-     * Return Chart.yaml fields.
-     * @return The fields.
+     * Obtain mapping for specified chart from `entries`.
+     * @param chartname Chart name
+     * @return Mapping for specified chart from `entries`.
      */
-    public Map<String, Object> fields() {
-        return this.yaml.blockingGet();
-    }
-
-    /**
-     * Obtain a field by name.
-     * @param name The name of field to read.
-     * @return A field the Yaml file.
-     */
-    private Object field(final String name) {
-        return this.yaml.blockingGet().get(name);
+    public List<Map<String, Object>> entriesByChart(final String chartname) {
+        return (List<Map<String, Object>>) this.entries().get(chartname);
     }
 }

--- a/src/main/java/com/artipie/helm/metadata/package-info.java
+++ b/src/main/java/com/artipie/helm/metadata/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Helm meta files.
+ *
+ * @since 0.2
+ */
+package com.artipie.helm.metadata;

--- a/src/test/java/com/artipie/helm/IndexYamlTest.java
+++ b/src/test/java/com/artipie/helm/IndexYamlTest.java
@@ -32,6 +32,7 @@ import com.artipie.asto.rx.RxStorageWrapper;
 import com.artipie.asto.test.TestResource;
 import com.artipie.helm.metadata.IndexYaml;
 import com.artipie.helm.metadata.IndexYamlMapping;
+import com.google.common.base.Throwables;
 import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -188,6 +189,7 @@ final class IndexYamlTest {
             new IsEqual<>(1)
         );
         MatcherAssert.assertThat(
+            "Correct chart was deleted",
             mapping.entries().containsKey("tomcat"),
             new IsEqual<>(true)
         );
@@ -196,11 +198,11 @@ final class IndexYamlTest {
     @Test
     void failsToDeleteChartByNameWhenIndexYamlAbsent() {
         MatcherAssert.assertThat(
-            new IndexYaml(this.storage, IndexYamlTest.BASE)
+            Throwables.getRootCause(
+                new IndexYaml(this.storage, IndexYamlTest.BASE)
                 .deleteByName("ark")
                 .blockingGet()
-                .getCause()
-                .getCause(),
+            ),
             new IsInstanceOf(FileNotFoundException.class)
         );
     }

--- a/src/test/resources/index.yaml
+++ b/src/test/resources/index.yaml
@@ -1,0 +1,54 @@
+generated: '2021-01-11T16:21:01.285921500+03:00'
+entries:
+  tomcat:
+  - maintainers:
+    - email: ybiran@ananware.systems
+      name: yahavb
+    urls:
+    - http://central.artipie.com/helm/tomcat-0.4.1.tgz
+    appVersion: '7.0'
+    apiVersion: v1
+    created: '2021-01-11T16:21:01.376598500+03:00'
+    digest: d8dcdcfcb512595960979cbd44728a8d8b0194c88335d0f84543e84b3939b8ce
+    icon: http://tomcat.apache.org/res/images/tomcat.png
+    name: tomcat
+    description: Deploy a basic tomcat application server with sidecar as web archive
+      container
+    version: 0.4.1
+    home: https://github.com/yahavb
+  ark:
+  - maintainers:
+    - email: d-caruso@hotmail.it
+      name: domcar
+    - email: unguiculus@gmail.com
+      name: unguiculus
+    urls:
+    - http://central.artipie.com/helm/ark-1.0.1.tgz
+    appVersion: 0.8.2
+    apiVersion: v1
+    sources:
+    - https://github.com/heptio/ark
+    created: '2021-01-11T16:21:01.461400100+03:00'
+    digest: b2f648cc0e2caad299ad008ecbb1d7330f61cc44cef5020b9de265cdd457a0dd
+    name: ark
+    description: A Helm chart for ark
+    version: 1.0.1
+    home: https://heptio.com/products/#heptio-ark
+  - maintainers:
+    - email: d-caruso@hotmail.it
+      name: domcar
+    - email: unguiculus@gmail.com
+      name: unguiculus
+    urls:
+    - http://central.artipie.com/helm/ark-1.2.0.tgz
+    appVersion: 0.9.1
+    apiVersion: v1
+    sources:
+    - https://github.com/heptio/ark
+    created: '2021-01-11T16:21:01.477022600+03:00'
+    digest: 4ae713c5afe86b9699a317f2b8a5847a9cd507038d96f12409b64e5c00319a8a
+    name: ark
+    description: A Helm chart for ark
+    version: 1.2.0
+    home: https://heptio.com/products/#heptio-ark
+apiVersion: v1


### PR DESCRIPTION
Part of #84  
Deleting by chart name was implemented. 
`IndexYamlMapping` was created to simplify working with `index.yaml` file. 
Added `@todo` to remove code duplication.
I am not sure about throwing exception for `Completable` with `doOnError`.