### PR TITLE
#86 - Remove code duplication in IndexYaml

### DIFF
--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -33,7 +33,9 @@ import com.artipie.asto.rx.RxStorageWrapper;
 import com.artipie.helm.ChartYaml;
 import com.artipie.helm.TgzArchive;
 import io.reactivex.Completable;
+import io.reactivex.CompletableSource;
 import io.reactivex.Single;
+import io.reactivex.functions.Function;
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
@@ -41,6 +43,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -67,9 +70,9 @@ public final class IndexYaml {
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.nnnnnnnnnZZZZZ");
 
     /**
-     * The storage.
+     * The RxStorage.
      */
-    private final Storage storage;
+    private final RxStorage storage;
 
     /**
      * The base path for urls field.
@@ -82,7 +85,7 @@ public final class IndexYaml {
      * @param base The base path for urls field.
      */
     public IndexYaml(final Storage storage, final String base) {
-        this.storage = storage;
+        this.storage = new RxStorageWrapper(storage);
         this.base = base;
     }
 
@@ -92,84 +95,34 @@ public final class IndexYaml {
      * @return The operation result
      */
     public Completable update(final TgzArchive arch) {
-        final RxStorage rxs = new RxStorageWrapper(this.storage);
-        return rxs.exists(IndexYaml.INDEX_YAML)
-            .flatMap(
-                exist -> {
-                    final Single<Map<String, Object>> result;
-                    if (exist) {
-                        result = rxs.value(IndexYaml.INDEX_YAML)
-                            .flatMap(content -> new Concatenation(content).single())
-                            .map(buf -> new String(new Remaining(buf).bytes()))
-                            .map(content -> new Yaml().load(content));
-                    } else {
-                        result = Single.just(IndexYaml.empty());
-                    }
-                    return result;
-                })
-            .map(
-                idx -> {
-                    this.update(idx, arch);
-                    return idx;
-                })
-            .flatMapCompletable(
-                idx -> {
-                    final DumperOptions options = new DumperOptions();
-                    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-                    options.setPrettyFlow(true);
-                    return rxs.save(
-                        IndexYaml.INDEX_YAML,
-                        new Content.From(
-                            new Yaml(options).dump(idx).getBytes(StandardCharsets.UTF_8)
-                        )
-                    );
-                }
-            );
+        return this.indexFromStrg(
+            Single.just(IndexYaml.empty())
+        ).map(
+            idx -> {
+                this.update(idx, arch);
+                return idx;
+            }
+        ).flatMapCompletable(new IndexToStorage());
     }
 
     /**
      * Delete from index.yaml file specified chart.
      * @param name Chart name
      * @return The operation result.
-     * @todo #84:30min Remove duplicating code.
-     *  There is duplicating code in this method and in `IndexYaml#update`. It is
-     *  necessary to remove this duplication.
      */
     public Completable deleteByName(final String name) {
-        final RxStorage rxs = new RxStorageWrapper(this.storage);
-        return rxs.exists(IndexYaml.INDEX_YAML)
-            .flatMap(
-                exist -> {
-                    final Single<Map<String, Object>>  result;
-                    if (exist) {
-                        result =
-                            rxs.value(IndexYaml.INDEX_YAML)
-                            .flatMap(content -> new Concatenation(content).single())
-                            .map(buf -> new String(new Remaining(buf).bytes()))
-                            .map(content -> new Yaml().load(content));
-                    } else {
-                        result = Single.error(
-                            new FileNotFoundException(
-                                String.format("File '%s' is not found", IndexYaml.INDEX_YAML)
-                            )
-                        );
-                    }
-                    return result;
-                }
-            ).flatMapCompletable(
-                idx -> {
-                    new IndexYamlMapping(idx).entries().remove(name);
-                    final DumperOptions options = new DumperOptions();
-                    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-                    options.setPrettyFlow(true);
-                    return rxs.save(
-                        IndexYaml.INDEX_YAML,
-                        new Content.From(
-                            new Yaml(options).dump(idx).getBytes(StandardCharsets.UTF_8)
-                        )
-                    );
-                }
-            );
+        return this.indexFromStrg(
+            Single.error(
+                new FileNotFoundException(
+                    String.format("File '%s' is not found", IndexYaml.INDEX_YAML)
+                )
+            )
+        ).map(
+            idx -> {
+                new IndexYamlMapping(idx).entries().remove(name);
+                return idx;
+            }
+        ).flatMapCompletable(new IndexToStorage());
     }
 
     /**
@@ -189,16 +142,12 @@ public final class IndexYaml {
      * @param index The index yaml mappings.
      * @param tgz The archive.
      */
-    @SuppressWarnings("unchecked")
     private void update(final Map<String, Object> index, final TgzArchive tgz) {
         final ChartYaml chart = tgz.chartYaml();
-        final Map<String, Object> entries = new IndexYamlMapping(index).entries();
+        final IndexYamlMapping mapping = new IndexYamlMapping(index);
         final String name = chart.name();
-        if (!entries.containsKey(name)) {
-            entries.put(name, new ArrayList<Map<String, Object>>(0));
-        }
-        final ArrayList<Map<String, Object>> versions = (ArrayList<Map<String, Object>>)
-            entries.get(name);
+        mapping.addChart(name, new ArrayList<Map<String, Object>>(0));
+        final List<Map<String, Object>> versions = mapping.entriesByChart(name);
         if (versions.stream().noneMatch(map -> map.get("version").equals(chart.version()))) {
             final Map<String, Object> newver = new HashMap<>();
             newver.put("created", ZonedDateTime.now().format(IndexYaml.TIME_FORMATTER));
@@ -214,6 +163,49 @@ public final class IndexYaml {
             //  One of the fields Index.yaml require is "urls" field. The test should make verify
             //  that field has been generated correctly.
             versions.add(newver);
+        }
+    }
+
+    /**
+     * Obtain index.yaml file from storage.
+     * @param notexist Value if index.yaml does not exist in the storage.
+     * @return Mapping for index.yaml if exists, otherwise value specified in the parameter.
+     */
+    private Single<Map<String, Object>> indexFromStrg(final Single<Map<String, Object>> notexist) {
+        return this.storage.exists(IndexYaml.INDEX_YAML)
+            .flatMap(
+                exist -> {
+                    final Single<Map<String, Object>>  result;
+                    if (exist) {
+                        result =
+                            this.storage.value(IndexYaml.INDEX_YAML)
+                                .flatMap(content -> new Concatenation(content).single())
+                                .map(buf -> new String(new Remaining(buf).bytes()))
+                                .map(content -> new Yaml().load(content));
+                    } else {
+                        result = notexist;
+                    }
+                    return result;
+                }
+            );
+    }
+
+    /**
+     * Save index mapping to storage.
+     * @since 0.2
+     */
+    private class IndexToStorage implements Function<Map<String, Object>, CompletableSource> {
+        @Override
+        public CompletableSource apply(final Map<String, Object> index) {
+            final DumperOptions options = new DumperOptions();
+            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+            options.setPrettyFlow(true);
+            return IndexYaml.this.storage.save(
+                IndexYaml.INDEX_YAML,
+                new Content.From(
+                    new Yaml(options).dump(index).getBytes(StandardCharsets.UTF_8)
+                )
+            );
         }
     }
 }

--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -144,7 +144,7 @@ public final class IndexYaml {
         final ChartYaml chart = tgz.chartYaml();
         final IndexYamlMapping mapping = new IndexYamlMapping(index);
         final String name = chart.name();
-        mapping.addChart(name, new ArrayList<Map<String, Object>>(0));
+        mapping.addNewChart(name, new ArrayList<Map<String, Object>>(0));
         final List<Map<String, Object>> versions = mapping.entriesByChart(name);
         if (versions.stream().noneMatch(map -> map.get("version").equals(chart.version()))) {
             final Map<String, Object> newver = new HashMap<>();

--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -33,9 +33,7 @@ import com.artipie.asto.rx.RxStorageWrapper;
 import com.artipie.helm.ChartYaml;
 import com.artipie.helm.TgzArchive;
 import io.reactivex.Completable;
-import io.reactivex.CompletableSource;
 import io.reactivex.Single;
-import io.reactivex.functions.Function;
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
@@ -102,7 +100,7 @@ public final class IndexYaml {
                 this.update(idx, arch);
                 return idx;
             }
-        ).flatMapCompletable(new IndexToStorage());
+        ).flatMapCompletable(this::indexToStorage);
     }
 
     /**
@@ -122,7 +120,7 @@ public final class IndexYaml {
                 new IndexYamlMapping(idx).entries().remove(name);
                 return idx;
             }
-        ).flatMapCompletable(new IndexToStorage());
+        ).flatMapCompletable(this::indexToStorage);
     }
 
     /**
@@ -192,20 +190,18 @@ public final class IndexYaml {
 
     /**
      * Save index mapping to storage.
-     * @since 0.2
+     * @param index Mapping for `index.yaml`
+     * @return The operation result.
      */
-    private class IndexToStorage implements Function<Map<String, Object>, CompletableSource> {
-        @Override
-        public CompletableSource apply(final Map<String, Object> index) {
-            final DumperOptions options = new DumperOptions();
-            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            options.setPrettyFlow(true);
-            return IndexYaml.this.storage.save(
-                IndexYaml.INDEX_YAML,
-                new Content.From(
-                    new Yaml(options).dump(index).getBytes(StandardCharsets.UTF_8)
-                )
-            );
-        }
+    private Completable indexToStorage(final Map<String, Object> index) {
+        final DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        return this.storage.save(
+            IndexYaml.INDEX_YAML,
+            new Content.From(
+                new Yaml(options).dump(index).getBytes(StandardCharsets.UTF_8)
+            )
+        );
     }
 }

--- a/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
@@ -72,4 +72,17 @@ public final class IndexYamlMapping {
     public List<Map<String, Object>> entriesByChart(final String chartname) {
         return (List<Map<String, Object>>) this.entries().get(chartname);
     }
+
+    /**
+     * Add info about chart to existing mapping.
+     * @param name Chart name
+     * @param versions Collection with mapping for different versions of specified chart
+     */
+    public void addChart(final String name, final List<Map<String, Object>> versions) {
+        final Map<String, Object> entr = this.entries();
+        if (!entr.containsKey(name)) {
+            entr.put(name, versions);
+        }
+    }
+
 }

--- a/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
@@ -74,11 +74,11 @@ public final class IndexYamlMapping {
     }
 
     /**
-     * Add info about chart to existing mapping.
+     * Add info about a new chart to the existing mapping.
      * @param name Chart name
      * @param versions Collection with mapping for different versions of specified chart
      */
-    public void addChart(final String name, final List<Map<String, Object>> versions) {
+    public void addNewChart(final String name, final List<Map<String, Object>> versions) {
         final Map<String, Object> entr = this.entries();
         if (!entr.containsKey(name)) {
             entr.put(name, versions);


### PR DESCRIPTION
Closes #86 
Removed code duplication in `IndexYaml`.
Added `IndexYamlMapping#addChart` to extract logic from `IndexYaml#update`