### PR TITLE
#90 - Add negative tests for IndexByDirectory

### DIFF
--- a/src/main/java/com/artipie/helm/metadata/IndexByDirectory.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexByDirectory.java
@@ -105,7 +105,9 @@ public class IndexByDirectory {
                     keys.stream()
                         .filter(key -> key.string().endsWith(IndexYaml.INDEX_YAML.string()))
                         .findFirst()
-                        .orElseThrow(IllegalStateException::new)
+                        .orElseThrow(
+                            () -> new IllegalStateException("'index.yaml' was not found in storage")
+                        )
                 ).thenApply(PublisherAs::new)
                 .thenCompose(PublisherAs::asciiString)
             )

--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -229,13 +228,10 @@ public final class IndexYaml {
      * @return The operation result.
      */
     private Completable indexToStorage(final Map<String, Object> index) {
-        final DumperOptions options = new DumperOptions();
-        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-        options.setPrettyFlow(true);
         return this.storage.save(
             IndexYaml.INDEX_YAML,
             new Content.From(
-                new Yaml(options).dump(index).getBytes(StandardCharsets.UTF_8)
+                new IndexYamlMapping(index).toString().getBytes(StandardCharsets.UTF_8)
             )
         );
     }

--- a/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -110,7 +111,7 @@ public final class IndexYamlMapping {
     }
 
     /**
-     * Coverts mapping to bytes.
+     * Converts mapping to bytes.
      * @return Bytes if entries mapping contains any chart, empty otherwise.
      */
     public Optional<byte[]> toBytes() {
@@ -126,6 +127,9 @@ public final class IndexYamlMapping {
 
     @Override
     public String toString() {
-        return new Yaml().dump(this.mapping);
+        final DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        return new Yaml(options).dump(this.mapping);
     }
 }


### PR DESCRIPTION
Part of #90 
Added negative test cases for `IndexByDirectory`. Used `toString()` in `IndexYaml`