### PR TITLE
#90 - Generate index by directory not using existing

### DIFF
--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -137,7 +137,7 @@ public final class IndexYaml {
                         .collect(Collectors.toList());
                     mapping.entries().remove(name);
                     if (!newvers.isEmpty()) {
-                        mapping.addNewChart(name, newvers);
+                        mapping.addChartVersions(name, newvers);
                     }
                     return idx;
                 }
@@ -178,7 +178,6 @@ public final class IndexYaml {
         final ChartYaml chart = tgz.chartYaml();
         final IndexYamlMapping mapping = new IndexYamlMapping(index);
         final String name = chart.name();
-        mapping.addNewChart(name, new ArrayList<Map<String, Object>>(0));
         final List<Map<String, Object>> versions = mapping.entriesByChart(name);
         if (versions.stream().noneMatch(map -> map.get("version").equals(chart.version()))) {
             final Map<String, Object> newver = new HashMap<>();

--- a/src/test/java/com/artipie/helm/HelmSliceIT.java
+++ b/src/test/java/com/artipie/helm/HelmSliceIT.java
@@ -28,6 +28,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.helm.metadata.IndexYamlMapping;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.StandardRs;
 import com.artipie.vertx.VertxSliceServer;
@@ -39,7 +40,6 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.shaded.org.yaml.snakeyaml.Yaml;
 
 /**
  * Push helm chart and ensure if index.yaml is generated properly.
@@ -139,13 +138,8 @@ public class HelmSliceIT {
      * @param yaml The index.yaml file passed as string
      * @return The first element in entries->tomcat
      */
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> tomcatZeroEntry(final String yaml) {
-        return (
-            (ArrayList<Map<String, Object>>)
-                ((Map<String, Object>) new Yaml().<Map<String, Object>>load(yaml)
-                    .get("entries")).get("tomcat")
-        ).get(0);
+        return new IndexYamlMapping(yaml).entriesByChart("tomcat").get(0);
     }
 
     /**

--- a/src/test/java/com/artipie/helm/metadata/IndexByDirectoryTest.java
+++ b/src/test/java/com/artipie/helm/metadata/IndexByDirectoryTest.java
@@ -35,14 +35,12 @@ import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link IndexByDirectory}.
  * @since 0.2
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class IndexByDirectoryTest {
@@ -59,14 +57,14 @@ final class IndexByDirectoryTest {
     @Test
     void worksProperlyForManyVersions() {
         final Key prefix = new Key.From("path/nested/");
-        Stream.of("ark-1.0.1.tgz", "ark-1.2.0.tgz", "tomcat-0.4.1.tgz", "index.yaml")
+        Stream.of("ark-1.0.1.tgz", "ark-1.2.0.tgz", "tomcat-0.4.1.tgz")
             .forEach(name -> this.saveByPrefix(prefix, name));
         this.storage.save(new Key.From("newpath/ark-0.2.2.tgz"), Content.EMPTY).join();
         this.storage.save(new Key.From(prefix, "not.txt"), Content.EMPTY).join();
         this.storage.save(new Key.From(prefix, "deep/sth-0.4.1.tgz"), Content.EMPTY).join();
         final IndexYamlMapping mapping = new IndexYamlMapping(
             new String(
-                new IndexByDirectory(this.storage, prefix)
+                new IndexByDirectory(this.storage, prefix, Optional.empty())
                     .value()
                     .toCompletableFuture().join()
                     .get()
@@ -86,9 +84,8 @@ final class IndexByDirectoryTest {
 
     @Test
     void returnsEmptyForEmptyDirectory() {
-        this.saveByPrefix(Key.ROOT, "index.yaml");
         MatcherAssert.assertThat(
-            new IndexByDirectory(this.storage, new Key.From("my/prefix"))
+            new IndexByDirectory(this.storage, new Key.From("my/prefix"), Optional.empty())
                 .value()
                 .toCompletableFuture().join()
                 .isPresent(),
@@ -97,29 +94,12 @@ final class IndexByDirectoryTest {
     }
 
     @Test
-    void throwsExceptionWhenIndexYamlNotFound() {
-        final Key dir = new Key.From("my/dir");
-        this.saveByPrefix(dir, "ark-1.0.1.tgz");
-        MatcherAssert.assertThat(
-            Throwables.getRootCause(this.throwable(dir).get()),
-            new IsInstanceOf(IllegalStateException.class)
-        );
-    }
-
-    @Test
     void throwsExceptionWhenTgzIsMalformed() {
         final Key dir = new Key.From("some/directory");
         this.saveByPrefix(dir, "index.yaml");
         this.storage.save(new Key.From(dir, "malformed-0.2.2.tgz"), Content.EMPTY).join();
-        MatcherAssert.assertThat(
-            Throwables.getRootCause(this.throwable(dir).get()).getMessage(),
-            new IsEqual<>("Input is not in the .gz format")
-        );
-    }
-
-    private AtomicReference<Throwable> throwable(final Key dir) {
         final AtomicReference<Throwable> exc = new AtomicReference<>();
-        new IndexByDirectory(this.storage, dir)
+        new IndexByDirectory(this.storage, dir, Optional.empty())
             .value()
             .handle(
                 (res, thr) -> {
@@ -128,7 +108,10 @@ final class IndexByDirectoryTest {
                 }
             ).toCompletableFuture()
             .join();
-        return exc;
+        MatcherAssert.assertThat(
+            Throwables.getRootCause(exc.get()).getMessage(),
+            new IsEqual<>("Input is not in the .gz format")
+        );
     }
 
     private void saveByPrefix(final Key prefix, final String name) {


### PR DESCRIPTION
Closes #90 
Implemented generating index by directory not using existing `index.yaml` file with info about charts. 