### PR TITLE
#89 - Merge `index.yaml` files

### DIFF
--- a/src/main/java/com/artipie/helm/metadata/IndexByDirectory.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexByDirectory.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.helm.metadata;
 
+import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
@@ -77,7 +78,7 @@ public class IndexByDirectory {
      * Obtains generated `index.yaml`.
      * @return Bytes of generated `index.yaml`, empty in case of absence of packaged charts.
      */
-    public CompletionStage<Optional<byte[]>> value() {
+    public CompletionStage<Optional<Content>> value() {
         final Map<String, List<Object>> entries = new ConcurrentHashMap<>();
         return this.storage.list(this.directory).thenCompose(
             keys -> CompletableFuture.allOf(
@@ -96,7 +97,7 @@ public class IndexByDirectory {
                     ).toArray(CompletableFuture[]::new)
             ).thenApply(nothing -> new IndexYamlMapping())
             .thenApply(index -> index.addEntries(entries))
-            .thenApply(IndexYamlMapping::toBytes)
+            .thenApply(IndexYamlMapping::toContent)
         );
     }
 

--- a/src/main/java/com/artipie/helm/metadata/IndexMerging.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexMerging.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm.metadata;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.ext.PublisherAs;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Merging two `index.yaml` files in one file.
+ * <ul>
+ *     <li>If source `index.yaml` and remote have the same version of chart,
+ *     data from remote chart should be taken</li>
+ *     <li>If source `index.yaml` does not have some charts or versions of chart,
+ *     `created` field for them should be updated during merge of the two indexes.</li>
+ * </ul>
+ * @since 0.2
+ */
+public final class IndexMerging {
+    /**
+     * Source `index.yaml` file. Another file will be merged to this one.
+     */
+    private final IndexYamlMapping source;
+
+    /**
+     * Ctor.
+     * @param source File `index.yaml` that will be merged
+     */
+    public IndexMerging(final IndexYamlMapping source) {
+        this.source = source;
+    }
+
+    /**
+     * Merges passed index with source index file.
+     * @param remote File `index.yaml` that will be merged
+     * @return Merged `index.yaml`
+     */
+    public CompletionStage<Content> mergeWith(final Content remote) {
+        return new PublisherAs(remote).asciiString()
+            .thenApply(IndexYamlMapping::new)
+            .thenApply(
+                index -> {
+                    for (final String name : index.entries().keySet()) {
+                        this.source.addChartVersions(name, index.byChart(name));
+                    }
+                    return this.source;
+                }
+            ).thenApply(IndexYamlMapping::toContent)
+            .thenApply(opt -> opt.orElse(Content.EMPTY));
+    }
+}

--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -132,7 +132,7 @@ public final class IndexYaml {
                 idx -> {
                     final IndexYamlMapping mapping = new IndexYamlMapping(idx);
                     final List<Map<String, Object>> newvers;
-                    newvers = mapping.entriesByChart(name).stream()
+                    newvers = mapping.byChart(name).stream()
                         .filter(entry -> !entry.get("version").equals(version))
                         .collect(Collectors.toList());
                     mapping.entries().remove(name);
@@ -178,7 +178,7 @@ public final class IndexYaml {
         final ChartYaml chart = tgz.chartYaml();
         final IndexYamlMapping mapping = new IndexYamlMapping(index);
         final String name = chart.name();
-        final List<Map<String, Object>> versions = mapping.entriesByChart(name);
+        final List<Map<String, Object>> versions = mapping.byChart(name);
         if (versions.stream().noneMatch(map -> map.get("version").equals(chart.version()))) {
             final Map<String, Object> newver = new HashMap<>();
             newver.put("created", ZonedDateTime.now().format(IndexYaml.TIME_FORMATTER));

--- a/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
@@ -131,6 +131,7 @@ public final class IndexYamlMapping {
                 existed.add(vers);
             }
         } else {
+            versions.forEach(vers -> vers.put("created", IndexYamlMapping.now()));
             entr.put(name, versions);
         }
     }

--- a/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYamlMapping.java
@@ -116,13 +116,13 @@ public final class IndexYamlMapping {
      */
     public void addChartVersions(final String name, final List<Map<String, Object>> versions) {
         final Map<String, Object> entr = this.entries();
+        versions.forEach(vers -> vers.put("created", IndexYamlMapping.now()));
         if (entr.containsKey(name)) {
             final List<Map<String, Object>> existed = this.byChart(name);
             for (final Map<String, Object> vers : versions) {
                 final Optional<Map<String, Object>> opt;
                 opt = this.byChartAndVersion(name, (String) vers.get(IndexYamlMapping.VRSN));
                 if (opt.isPresent()) {
-                    vers.put("created", IndexYamlMapping.now());
                     existed.removeIf(
                         chart -> chart.get(IndexYamlMapping.VRSN)
                             .equals(opt.get().get(IndexYamlMapping.VRSN))
@@ -131,7 +131,6 @@ public final class IndexYamlMapping {
                 existed.add(vers);
             }
         } else {
-            versions.forEach(vers -> vers.put("created", IndexYamlMapping.now()));
             entr.put(name, versions);
         }
     }

--- a/src/test/java/com/artipie/helm/HelmSliceIT.java
+++ b/src/test/java/com/artipie/helm/HelmSliceIT.java
@@ -139,7 +139,7 @@ public class HelmSliceIT {
      * @return The first element in entries->tomcat
      */
     private static Map<String, Object> tomcatZeroEntry(final String yaml) {
-        return new IndexYamlMapping(yaml).entriesByChart("tomcat").get(0);
+        return new IndexYamlMapping(yaml).byChart("tomcat").get(0);
     }
 
     /**

--- a/src/test/java/com/artipie/helm/IndexYamlTest.java
+++ b/src/test/java/com/artipie/helm/IndexYamlTest.java
@@ -90,7 +90,7 @@ final class IndexYamlTest {
     @Test
     void verifyDigestFromIndex() {
         this.update(IndexYamlTest.TOMCAT);
-        final List<Map<String, Object>> tomcat = this.mapping().entriesByChart("tomcat");
+        final List<Map<String, Object>> tomcat = this.mapping().byChart("tomcat");
         MatcherAssert.assertThat(
             tomcat.get(0).get("digest"),
             new IsEqual<>(
@@ -103,9 +103,9 @@ final class IndexYamlTest {
     void notChangeForSameChartWithSameVersion() {
         this.update(IndexYamlTest.TOMCAT);
         final String tomcat = "tomcat";
-        final Map<String, Object> old = this.mapping().entriesByChart(tomcat).get(0);
+        final Map<String, Object> old = this.mapping().byChart(tomcat).get(0);
         this.update(IndexYamlTest.TOMCAT);
-        final List<Map<String, Object>> updt = this.mapping().entriesByChart(tomcat);
+        final List<Map<String, Object>> updt = this.mapping().byChart(tomcat);
         MatcherAssert.assertThat(
             "New version was not added",
             updt.size(),
@@ -123,7 +123,7 @@ final class IndexYamlTest {
         this.update(IndexYamlTest.TOMCAT);
         this.update(IndexYamlTest.ARK);
         this.update("ark-1.2.0.tgz");
-        final List<Map<String, Object>> entries = this.mapping().entriesByChart("ark");
+        final List<Map<String, Object>> entries = this.mapping().byChart("ark");
         MatcherAssert.assertThat(
             "New version was added",
             entries.size(),
@@ -143,7 +143,7 @@ final class IndexYamlTest {
     void addMetadataForNewChartInExistingIndex() {
         this.update(IndexYamlTest.TOMCAT);
         this.update(IndexYamlTest.ARK);
-        final Map<String, Object> ark = this.mapping().entriesByChart("ark").get(0);
+        final Map<String, Object> ark = this.mapping().byChart("ark").get(0);
         final Map<String, Object> chart = this.chartYaml(IndexYamlTest.ARK);
         final int numgenfields = 3;
         MatcherAssert.assertThat(
@@ -217,15 +217,13 @@ final class IndexYamlTest {
         final IndexYamlMapping mapping = this.mapping();
         MatcherAssert.assertThat(
             "Number of versions of chart is correct",
-            mapping.entriesByChart(chart).size(),
+            mapping.byChart(chart).size(),
             new IsEqual<>(1)
         );
         MatcherAssert.assertThat(
             "Correct version of chart was deleted",
-            mapping.entriesByChart(chart)
-                .get(0)
-                .get("version"),
-            new IsEqual<>("1.2.0")
+            mapping.byChartAndVersion(chart, "1.2.0").isPresent(),
+            new IsEqual<>(true)
         );
     }
 
@@ -263,7 +261,7 @@ final class IndexYamlTest {
             .blockingGet();
         final IndexYamlMapping mapping = this.mapping();
         MatcherAssert.assertThat(
-            mapping.entriesByChart(chart).size(),
+            mapping.byChart(chart).size(),
             new IsEqual<>(1)
         );
     }

--- a/src/test/java/com/artipie/helm/metadata/IndexByDirectoryTest.java
+++ b/src/test/java/com/artipie/helm/metadata/IndexByDirectoryTest.java
@@ -26,6 +26,7 @@ package com.artipie.helm.metadata;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
 import com.google.common.base.Throwables;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case for {@link IndexByDirectory}.
  * @since 0.2
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class IndexByDirectoryTest {
@@ -63,12 +65,13 @@ final class IndexByDirectoryTest {
         this.storage.save(new Key.From(prefix, "not.txt"), Content.EMPTY).join();
         this.storage.save(new Key.From(prefix, "deep/sth-0.4.1.tgz"), Content.EMPTY).join();
         final IndexYamlMapping mapping = new IndexYamlMapping(
-            new String(
+            new PublisherAs(
                 new IndexByDirectory(this.storage, prefix, Optional.empty())
                     .value()
                     .toCompletableFuture().join()
                     .get()
-            )
+            ).asciiString()
+            .toCompletableFuture().join()
         );
         MatcherAssert.assertThat(
             "Contains required charts",
@@ -77,7 +80,7 @@ final class IndexByDirectoryTest {
         );
         MatcherAssert.assertThat(
             "Contains both versions of chart",
-            mapping.entriesByChart("ark").size(),
+            mapping.byChart("ark").size(),
             new IsEqual<>(2)
         );
     }

--- a/src/test/java/com/artipie/helm/metadata/IndexMergingTest.java
+++ b/src/test/java/com/artipie/helm/metadata/IndexMergingTest.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm.metadata;
+
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.asto.test.TestResource;
+import java.util.stream.Collectors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for {@link IndexMerging}.
+ * @since 0.2
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class IndexMergingTest {
+    /**
+     * Remote `index.yaml`.
+     */
+    private IndexYamlMapping source;
+
+    @BeforeEach
+    void setUp() {
+        this.source = this.index("merge/source/index.yaml");
+    }
+
+    @Test
+    void mergedFileContainsRequiredCharts() {
+        final IndexYamlMapping target = this.index("merge/target/index.yaml");
+        MatcherAssert.assertThat(
+            this.mergedIndex().entries().keySet(),
+            Matchers.containsInAnyOrder(target.entries().keySet().toArray())
+        );
+    }
+
+    @Test
+    void tomcatContainsBothRequiredVersions() {
+        final String chart = "tomcat";
+        final IndexYamlMapping target = this.index("merge/target/index.yaml");
+        MatcherAssert.assertThat(
+            this.mergedIndex().byChart(chart).stream()
+                .map(entry -> (String) entry.get("version"))
+                .collect(Collectors.toList()),
+            Matchers.containsInAnyOrder(
+                target.byChart(chart).stream()
+                    .map(entry -> (String) entry.get("version"))
+                    .toArray(String[]::new)
+            )
+        );
+    }
+
+    @Test
+    void datetimeWasUpdated() {
+        final String chart = "tomcat";
+        final String version = "0.1.0";
+        final String created = "created";
+        final String old = (String) this.source
+            .byChartAndVersion(chart, version)
+            .get().get(created);
+        final String updated = (String) this.mergedIndex()
+            .byChartAndVersion(chart, version)
+            .get().get(created);
+        MatcherAssert.assertThat(
+            old.equals(updated),
+            new IsEqual<>(false)
+        );
+    }
+
+    @Test
+    void rightEntryWasSelectedWhenVersionExistsInBoth() {
+        final String chart = "tomcat";
+        final String version = "0.1.0";
+        final String descr = "description";
+        MatcherAssert.assertThat(
+            this.mergedIndex()
+                .byChartAndVersion(chart, version)
+                .get().get(descr),
+            new IsEqual<>(
+                this.source.byChartAndVersion(chart, version)
+                    .get().get(descr)
+            )
+        );
+    }
+
+    private IndexYamlMapping index(final String path) {
+        return new IndexYamlMapping(
+            new String(
+                new TestResource(path).asBytes()
+            )
+        );
+    }
+
+    private IndexYamlMapping mergedIndex() {
+        final IndexYamlMapping remote = this.index("merge/remote/index.yaml");
+        return new IndexYamlMapping(
+            new PublisherAs(
+                new IndexMerging(this.source)
+                    .mergeWith(remote.toContent().get())
+                    .toCompletableFuture().join()
+            ).asciiString()
+            .toCompletableFuture().join()
+        );
+    }
+}

--- a/src/test/java/com/artipie/helm/metadata/IndexMergingTest.java
+++ b/src/test/java/com/artipie/helm/metadata/IndexMergingTest.java
@@ -50,7 +50,7 @@ final class IndexMergingTest {
 
     @Test
     void mergedFileContainsRequiredCharts() {
-        final IndexYamlMapping target = this.index("merge/target/index.yaml");
+        final IndexYamlMapping target = this.index("merge/output/index.yaml");
         MatcherAssert.assertThat(
             this.mergedIndex().entries().keySet(),
             Matchers.containsInAnyOrder(target.entries().keySet().toArray())
@@ -60,7 +60,7 @@ final class IndexMergingTest {
     @Test
     void tomcatContainsBothRequiredVersions() {
         final String chart = "tomcat";
-        final IndexYamlMapping target = this.index("merge/target/index.yaml");
+        final IndexYamlMapping target = this.index("merge/output/index.yaml");
         MatcherAssert.assertThat(
             this.mergedIndex().byChart(chart).stream()
                 .map(entry -> (String) entry.get("version"))

--- a/src/test/resources/merge/output/index.yaml
+++ b/src/test/resources/merge/output/index.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+entries:
+  ark:
+  - apiVersion: v1
+    appVersion: 0.8.2
+    created: "2021-01-11T16:21:01.4614001+03:00"
+    description: A Helm chart for ark
+    digest: b2f648cc0e2caad299ad008ecbb1d7330f61cc44cef5020b9de265cdd457a0dd
+    home: https://heptio.com/products/#heptio-ark
+    maintainers:
+    - email: d-caruso@hotmail.it
+      name: domcar
+    - email: unguiculus@gmail.com
+      name: unguiculus
+    name: ark
+    sources:
+    - https://github.com/heptio/ark
+    urls:
+    - http://central.artipie.com/helm/ark-1.0.1.tgz
+    version: 1.0.1
+  mychart:
+  - apiVersion: v1
+    appVersion: "1.0"
+    created: "2021-01-21T16:40:54.0752761+03:00"
+    description: A Helm chart for Kubernetes
+    digest: 1224ddf156c5a3c1688afc42985efceb246d4750fad9b6b2f22405f0fd0fc120
+    name: mychart
+    urls:
+    - https://charts.helm.sh/stable/mychart-0.1.0.tgz
+    version: 0.1.0
+  tomcat:
+  - apiVersion: v1
+    appVersion: "7.0"
+    created: "2021-01-11T16:21:01.3765985+03:00"
+    description: Deploy a basic tomcat application server with sidecar as web archive
+      container
+    digest: d8dcdcfcb512595960979cbd44728a8d8b0194c88335d0f84543e84b3939b8ce
+    home: https://github.com/yahavb
+    icon: http://tomcat.apache.org/res/images/tomcat.png
+    maintainers:
+    - email: ybiran@ananware.systems
+      name: yahavb
+    name: tomcat
+    urls:
+    - http://central.artipie.com/helm/tomcat-0.4.1.tgz
+    version: 0.4.1
+  - apiVersion: v1
+    appVersion: "1.0"
+    created: "2021-01-21T16:40:54.0762778+03:00"
+    description: Tomcat 0.1.0 from remote
+    digest: 1d8ff8937ed45e7a508e6c6d03de01de2e0b5a8f0aaba2fda84415fcaff7ac7e
+    name: tomcat
+    urls:
+    - https://charts.helm.sh/stable/tomcat-0.1.0.tgz
+    version: 0.1.0
+generated: "2021-01-21T16:40:54.0742762+03:00"

--- a/src/test/resources/merge/remote/index.yaml
+++ b/src/test/resources/merge/remote/index.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+entries:
+  mychart:
+  - apiVersion: v1
+    appVersion: "1.0"
+    created: "2021-01-21T16:00:32.0799188+03:00"
+    description: A Helm chart for Kubernetes
+    digest: 1224ddf156c5a3c1688afc42985efceb246d4750fad9b6b2f22405f0fd0fc120
+    name: mychart
+    urls:
+    - https://charts.helm.sh/stable/mychart-0.1.0.tgz
+    version: 0.1.0
+  tomcat:
+  - apiVersion: v1
+    appVersion: "1.0"
+    created: "2021-01-21T16:12:01.7438669+03:00"
+    description: Tomcat 0.1.0 from remote
+    digest: 1d8ff8937ed45e7a508e6c6d03de01de2e0b5a8f0aaba2fda84415fcaff7ac7e
+    name: tomcat
+    urls:
+    - https://charts.helm.sh/stable/tomcat-0.1.0.tgz
+    version: 0.1.0
+generated: "2021-01-21T16:00:32.0789176+03:00"

--- a/src/test/resources/merge/source/index.yaml
+++ b/src/test/resources/merge/source/index.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+entries:
+  tomcat:
+  - apiVersion: v1
+    appVersion: "7.0"
+    created: "2021-01-11T16:21:01.3765985+03:00"
+    description: Deploy a basic tomcat application server with sidecar as web archive
+      container
+    digest: d8dcdcfcb512595960979cbd44728a8d8b0194c88335d0f84543e84b3939b8ce
+    home: https://github.com/yahavb
+    icon: http://tomcat.apache.org/res/images/tomcat.png
+    maintainers:
+    - email: ybiran@ananware.systems
+      name: yahavb
+    name: tomcat
+    urls:
+    - http://central.artipie.com/helm/tomcat-0.4.1.tgz
+    version: 0.4.1
+  - apiVersion: v1
+    appVersion: "1.0"
+    created: "2021-01-21T16:00:32.0809164+03:00"
+    description: Existed tomcat with 0.1.0
+    digest: bfb24b1aa73bf9ac8ccc976d1c40bd494345572f00aedbb5b2abb8d71568aac7
+    name: tomcat
+    urls:
+    - https://charts.helm.sh/stable/tomcat-0.1.0.tgz
+    version: 0.1.0
+  ark:
+  - maintainers:
+    - email: d-caruso@hotmail.it
+      name: domcar
+    - email: unguiculus@gmail.com
+      name: unguiculus
+    urls:
+    - http://central.artipie.com/helm/ark-1.0.1.tgz
+    appVersion: 0.8.2
+    apiVersion: v1
+    sources:
+    - https://github.com/heptio/ark
+    created: '2021-01-11T16:21:01.461400100+03:00'
+    digest: b2f648cc0e2caad299ad008ecbb1d7330f61cc44cef5020b9de265cdd457a0dd
+    name: ark
+    description: A Helm chart for ark
+    version: 1.0.1
+    home: https://heptio.com/products/#heptio-ark
+generated: "2021-01-21T16:00:32.0789176+03:00"


### PR DESCRIPTION
Closes #89 
Implemented merging `index.yaml` files. For testing, I used file that was obtained after merge two indexes with command
`helm repo index --merge index.yaml --url http://charts.helm.sh/charts/ ./`