### PR TITLE
#96 - Add prefix during download, not use prefix when pushing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.14.3</version>
+      <version>1.15.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/artipie/helm/http/DownloadIndexSlice.java
+++ b/src/main/java/com/artipie/helm/http/DownloadIndexSlice.java
@@ -181,13 +181,30 @@ final class DownloadIndexSlice implements Slice {
                         entr.put(
                             key,
                             urls.stream()
-                                .map(uri -> String.format("%s/%s", this.base, uri))
+                                .map(this::baseUrlWithUri)
                                 .collect(Collectors.toList())
                         );
                     }
                 )
             );
             return index;
+        }
+
+        /**
+         * Combine base url with uri.
+         * @param uri Uri
+         * @return Url that was obtained after combining.
+         */
+        private String baseUrlWithUri(final String uri) {
+            final String unsafe = String.format("%s/%s", this.base, uri);
+            try {
+                return new URL(unsafe).toString();
+            } catch (final MalformedURLException exc) {
+                throw new IllegalStateException(
+                    String.format("Failed to create URL from `%s`", unsafe),
+                    exc
+                );
+            }
         }
     }
 }

--- a/src/main/java/com/artipie/helm/http/DownloadIndexSlice.java
+++ b/src/main/java/com/artipie/helm/http/DownloadIndexSlice.java
@@ -1,0 +1,193 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm.http;
+
+import com.artipie.asto.Concatenation;
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.helm.metadata.IndexYamlMapping;
+import com.artipie.http.Headers;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.rs.RsFull;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.rs.StandardRs;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.reactivestreams.Publisher;
+
+/**
+ * Download index file endpoint. Return index file with urls that are
+ * based on requested URL.
+ * @since 0.3
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+final class DownloadIndexSlice implements Slice {
+    /**
+     * Endpoint request line pattern.
+     */
+    static final Pattern PTRN = Pattern.compile(".*index.yaml$");
+
+    /**
+     * Base URL.
+     */
+    private final URL base;
+
+    /**
+     * Abstract Storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Ctor.
+     *
+     * @param base Base URL
+     * @param storage Abstract storage
+     */
+    DownloadIndexSlice(final String base, final Storage storage) {
+        this.base = DownloadIndexSlice.url(base);
+        this.storage = storage;
+    }
+
+    @Override
+    public Response response(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
+        final Key path = new Key.From(line);
+        return new AsyncResponse(
+            this.storage.exists(path).thenCompose(
+                exists -> {
+                    final CompletableFuture<Response> rsp;
+                    if (exists) {
+                        rsp = this.storage.value(path)
+                            .thenCompose(content -> new UpdateIndexUrls(content, this.base).value())
+                            .thenApply(
+                                content -> new RsFull(RsStatus.OK, Headers.EMPTY, content)
+                            );
+                    } else {
+                        rsp = CompletableFuture.completedFuture(StandardRs.NOT_FOUND);
+                    }
+                    return rsp;
+                }
+            )
+        );
+    }
+
+    /**
+     * Converts string with url to URL.
+     * @param url String with url
+     * @return URL from string with url.
+     */
+    private static URL url(final String url) {
+        try {
+            return new URL(url.replaceAll("/$", ""));
+        } catch (final MalformedURLException exc) {
+            throw new IllegalArgumentException(
+                String.format("Failed to build URL from '%s'", url),
+                exc
+            );
+        }
+    }
+
+    /**
+     * Prepends all urls in the index file with the prefix to build
+     * absolute URL: chart-0.4.1.tgz -&gt; http://host:port/path/chart-0.4.1.tgz.
+     * @since 0.3
+     */
+    private static final class UpdateIndexUrls {
+        /**
+         * Original content.
+         */
+        private final Content original;
+
+        /**
+         * Base URL.
+         */
+        private final URL base;
+
+        /**
+         * Ctor.
+         * @param original Original content
+         * @param base Base URL
+         */
+        UpdateIndexUrls(final Content original, final URL base) {
+            this.original = original;
+            this.base = base;
+        }
+
+        /**
+         * Return modified content with prepended URLs.
+         * @return Modified content with prepended URLs
+         */
+        public CompletableFuture<Content> value() {
+            return new Concatenation(this.original)
+                .single()
+                .map(ByteBuffer::array)
+                .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .map(IndexYamlMapping::new)
+                .map(this::update)
+                .map(idx -> idx.toContent().get())
+                .to(SingleInterop.get())
+                .toCompletableFuture();
+        }
+
+        /**
+         * Updates urls for index file.
+         * @param index Index yaml mapping
+         * @return Index yaml mapping with updated urls.
+         */
+        @SuppressWarnings("unchecked")
+        private IndexYamlMapping update(final IndexYamlMapping index) {
+            final Set<String> entrs = index.entries().keySet();
+            entrs.forEach(
+                chart -> index.byChart(chart).forEach(
+                    entr -> {
+                        final String key = "url";
+                        final List<String> urls = (List<String>) entr.get(key);
+                        entr.put(
+                            key,
+                            urls.stream()
+                                .map(uri -> String.format("%s/%s", this.base, uri))
+                                .collect(Collectors.toList())
+                        );
+                    }
+                )
+            );
+            return index;
+        }
+    }
+}

--- a/src/main/java/com/artipie/helm/http/HelmSlice.java
+++ b/src/main/java/com/artipie/helm/http/HelmSlice.java
@@ -66,6 +66,7 @@ public final class HelmSlice extends Slice.Wrap {
      * @param perms Access permissions.
      * @param auth Authentication.
      */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
     public HelmSlice(
         final Storage storage,
         final String base,
@@ -82,17 +83,6 @@ public final class HelmSlice extends Slice.Wrap {
                         new PushChartSlice(storage),
                         auth,
                         new Permission.ByName(perms, Action.Standard.WRITE)
-                    )
-                ),
-                new RtRulePath(
-                    new RtRule.All(
-                        new ByMethodsRule(RqMethod.GET),
-                        new RtRule.ByPath(DownloadIndexSlice.PTRN)
-                    ),
-                    new BasicAuthSlice(
-                        new DownloadIndexSlice(base, storage),
-                        auth,
-                        new Permission.ByName(perms, Action.Standard.READ)
                     )
                 ),
                 new RtRulePath(

--- a/src/main/java/com/artipie/helm/http/HelmSlice.java
+++ b/src/main/java/com/artipie/helm/http/HelmSlice.java
@@ -21,8 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
-package com.artipie.helm;
+package com.artipie.helm.http;
 
 import com.artipie.asto.Storage;
 import com.artipie.http.Slice;
@@ -80,9 +79,20 @@ public final class HelmSlice extends Slice.Wrap {
                         new ByMethodsRule(RqMethod.POST)
                     ),
                     new BasicAuthSlice(
-                        new PushChartSlice(storage, base),
+                        new PushChartSlice(storage),
                         auth,
                         new Permission.ByName(perms, Action.Standard.WRITE)
+                    )
+                ),
+                new RtRulePath(
+                    new RtRule.All(
+                        new ByMethodsRule(RqMethod.GET),
+                        new RtRule.ByPath(DownloadIndexSlice.PTRN)
+                    ),
+                    new BasicAuthSlice(
+                        new DownloadIndexSlice(base, storage),
+                        auth,
+                        new Permission.ByName(perms, Action.Standard.READ)
                     )
                 ),
                 new RtRulePath(

--- a/src/main/java/com/artipie/helm/http/package-info.java
+++ b/src/main/java/com/artipie/helm/http/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Helm repository HTTP API.
+ * @since 0.3
+ */
+package com.artipie.helm.http;

--- a/src/main/java/com/artipie/helm/metadata/IndexMerging.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexMerging.java
@@ -29,12 +29,8 @@ import java.util.concurrent.CompletionStage;
 
 /**
  * Merging two `index.yaml` files in one file.
- * <ul>
- *     <li>If source `index.yaml` and remote have the same version of chart,
- *     data from remote chart should be taken</li>
- *     <li>If source `index.yaml` does not have some charts or versions of chart,
- *     `created` field for them should be updated during merge of the two indexes.</li>
- * </ul>
+ * If source `index.yaml` does not have some charts or versions of chart,
+ * `created` field for them should be updated during merge of the two indexes.
  * @since 0.2
  */
 public final class IndexMerging {

--- a/src/main/java/com/artipie/helm/metadata/IndexYaml.java
+++ b/src/main/java/com/artipie/helm/metadata/IndexYaml.java
@@ -55,7 +55,6 @@ import org.yaml.snakeyaml.Yaml;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class IndexYaml {
-
     /**
      * An example of time this formatter produces: 2016-10-06T16:23:20.499814565-06:00 .
      */
@@ -73,18 +72,11 @@ public final class IndexYaml {
     private final RxStorage storage;
 
     /**
-     * The base path for urls field.
-     */
-    private final String base;
-
-    /**
      * Ctor.
      * @param storage The storage.
-     * @param base The base path for urls field.
      */
-    public IndexYaml(final Storage storage, final String base) {
+    public IndexYaml(final Storage storage) {
         this.storage = new RxStorageWrapper(storage);
-        this.base = base;
     }
 
     /**
@@ -97,7 +89,7 @@ public final class IndexYaml {
             Single.just(IndexYaml.empty())
         ).map(
             idx -> {
-                this.update(idx, arch);
+                IndexYaml.update(idx, arch);
                 return idx;
             }
         ).flatMapCompletable(this::indexToStorage);
@@ -174,7 +166,7 @@ public final class IndexYaml {
      * @param index The index yaml mappings.
      * @param tgz The archive.
      */
-    private void update(final Map<String, Object> index, final TgzArchive tgz) {
+    private static void update(final Map<String, Object> index, final TgzArchive tgz) {
         final ChartYaml chart = tgz.chartYaml();
         final IndexYamlMapping mapping = new IndexYamlMapping(index);
         final String name = chart.name();
@@ -185,7 +177,7 @@ public final class IndexYaml {
             newver.put(
                 "urls",
                 new ArrayList<>(
-                    Collections.singleton(String.format("%s%s", this.base, tgz.name()))
+                    Collections.singleton(tgz.name())
                 )
             );
             newver.put("digest", tgz.digest());

--- a/src/test/java/com/artipie/helm/HelmCompatibilityITCase.java
+++ b/src/test/java/com/artipie/helm/HelmCompatibilityITCase.java
@@ -26,6 +26,7 @@ package com.artipie.helm;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
+import com.artipie.helm.http.HelmSlice;
 import com.artipie.http.auth.Authentication;
 import com.artipie.http.auth.JoinedPermissions;
 import com.artipie.http.auth.Permissions;

--- a/src/test/java/com/artipie/helm/HelmSliceIT.java
+++ b/src/test/java/com/artipie/helm/HelmSliceIT.java
@@ -123,8 +123,7 @@ public class HelmSliceIT {
                     tomcatZeroEntry(expected),
                     tomcatZeroEntry(adapter)
                 ).entriesDiffering(),
-                ComposeMatchers.compose(new IsMapWithSize<String, Object>(new IsEqual<>(2)))
-                    .and(new IsMapContaining<>(new IsEqual<>("urls"), new IsAnything<>()))
+                ComposeMatchers.compose(new IsMapWithSize<String, Object>(new IsEqual<>(1)))
                     .and(new IsMapContaining<>(new IsEqual<>("created"), new IsAnything<>()))
             );
         } finally {

--- a/src/test/java/com/artipie/helm/HelmSliceIT.java
+++ b/src/test/java/com/artipie/helm/HelmSliceIT.java
@@ -28,6 +28,7 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.blocking.BlockingStorage;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.helm.http.HelmSlice;
 import com.artipie.helm.metadata.IndexYamlMapping;
 import com.artipie.http.rs.RsStatus;
 import com.artipie.http.rs.StandardRs;

--- a/src/test/java/com/artipie/helm/IndexYamlTest.java
+++ b/src/test/java/com/artipie/helm/IndexYamlTest.java
@@ -67,11 +67,6 @@ final class IndexYamlTest {
     private static final String ARK = "ark-1.0.1.tgz";
 
     /**
-     * Base string.
-     */
-    private static final String BASE = "http://central.artipie.com/helm/";
-
-    /**
      * Storage.
      */
     private Storage storage;
@@ -84,7 +79,7 @@ final class IndexYamlTest {
     @BeforeEach
     void init() {
         this.storage = new InMemoryStorage();
-        this.yaml = new IndexYaml(this.storage, IndexYamlTest.BASE);
+        this.yaml = new IndexYaml(this.storage);
     }
 
     @Test
@@ -163,11 +158,7 @@ final class IndexYamlTest {
                     this.matcher("description", chart),
                     this.matcher("home", chart),
                     this.matcher("maintainers", chart),
-                    Matchers.hasEntry(
-                        "urls", Collections.singletonList(
-                            String.format("%s%s", IndexYamlTest.BASE, IndexYamlTest.ARK)
-                        )
-                    ),
+                    Matchers.hasEntry("urls", Collections.singletonList(IndexYamlTest.ARK)),
                     Matchers.hasEntry(
                         "sources", Collections.singletonList("https://github.com/heptio/ark")
                     ),
@@ -181,7 +172,7 @@ final class IndexYamlTest {
     @Test
     void deleteChartByNameFromIndexYaml() {
         new TestResource("index.yaml").saveTo(this.storage);
-        new IndexYaml(this.storage, IndexYamlTest.BASE).deleteByName("ark").blockingGet();
+        this.yaml.deleteByName("ark").blockingGet();
         final IndexYamlMapping mapping = this.mapping();
         MatcherAssert.assertThat(
             "Number of charts is correct",
@@ -198,11 +189,7 @@ final class IndexYamlTest {
     @Test
     void failsToDeleteChartByNameWhenIndexYamlAbsent() {
         MatcherAssert.assertThat(
-            Throwables.getRootCause(
-                new IndexYaml(this.storage, IndexYamlTest.BASE)
-                .deleteByName("ark")
-                .blockingGet()
-            ),
+            Throwables.getRootCause(this.yaml.deleteByName("ark").blockingGet()),
             new IsInstanceOf(FileNotFoundException.class)
         );
     }
@@ -211,9 +198,7 @@ final class IndexYamlTest {
     void deleteChartByNameVersionWithManyVersionsFromIndex() {
         final String chart = "ark";
         new TestResource("index.yaml").saveTo(this.storage);
-        new IndexYaml(this.storage, IndexYamlTest.BASE)
-            .deleteByNameAndVersion(chart, "1.0.1")
-            .blockingGet();
+        this.yaml.deleteByNameAndVersion(chart, "1.0.1").blockingGet();
         final IndexYamlMapping mapping = this.mapping();
         MatcherAssert.assertThat(
             "Number of versions of chart is correct",
@@ -231,9 +216,7 @@ final class IndexYamlTest {
     void deleteChartByNameVersionWithSingleVersionFromIndex() {
         final String chart = "tomcat";
         new TestResource("index.yaml").saveTo(this.storage);
-        new IndexYaml(this.storage, IndexYamlTest.BASE)
-            .deleteByNameAndVersion(chart, "0.4.1")
-            .blockingGet();
+        this.yaml.deleteByNameAndVersion(chart, "0.4.1").blockingGet();
         MatcherAssert.assertThat(
             this.mapping().entries().containsKey(chart),
             new IsEqual<>(false)
@@ -243,9 +226,7 @@ final class IndexYamlTest {
     @Test
     void deleteAbsentChartByNameFromIndex() {
         new TestResource("index.yaml").saveTo(this.storage);
-        new IndexYaml(this.storage, IndexYamlTest.BASE)
-            .deleteByName("absent")
-            .blockingGet();
+        this.yaml.deleteByName("absent").blockingGet();
         MatcherAssert.assertThat(
             this.mapping().entries().size(),
             new IsEqual<>(2)
@@ -256,9 +237,7 @@ final class IndexYamlTest {
     void deleteChartByNameAndAbsentVersionFromIndex() {
         final String chart = "tomcat";
         new TestResource("index.yaml").saveTo(this.storage);
-        new IndexYaml(this.storage, IndexYamlTest.BASE)
-            .deleteByNameAndVersion(chart, "0.0.0")
-            .blockingGet();
+        this.yaml.deleteByNameAndVersion(chart, "0.0.0").blockingGet();
         final IndexYamlMapping mapping = this.mapping();
         MatcherAssert.assertThat(
             mapping.byChart(chart).size(),

--- a/src/test/java/com/artipie/helm/http/BufsToByteArrTest.java
+++ b/src/test/java/com/artipie/helm/http/BufsToByteArrTest.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.artipie.helm;
+package com.artipie.helm.http;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/src/test/java/com/artipie/helm/http/package-info.java
+++ b/src/test/java/com/artipie/helm/http/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tests for HTTP Helm objects.
+ * @since 0.3
+ */
+package com.artipie.helm.http;

--- a/src/test/java/com/artipie/helm/metadata/IndexMergingTest.java
+++ b/src/test/java/com/artipie/helm/metadata/IndexMergingTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class IndexMergingTest {
     /**
-     * Remote `index.yaml`.
+     * Source `index.yaml`.
      */
     private IndexYamlMapping source;
 

--- a/src/test/resources/index.yaml
+++ b/src/test/resources/index.yaml
@@ -5,7 +5,7 @@ entries:
     - email: ybiran@ananware.systems
       name: yahavb
     urls:
-    - http://central.artipie.com/helm/tomcat-0.4.1.tgz
+    - tomcat-0.4.1.tgz
     appVersion: '7.0'
     apiVersion: v1
     created: '2021-01-11T16:21:01.376598500+03:00'
@@ -23,7 +23,7 @@ entries:
     - email: unguiculus@gmail.com
       name: unguiculus
     urls:
-    - http://central.artipie.com/helm/ark-1.0.1.tgz
+    - ark-1.0.1.tgz
     appVersion: 0.8.2
     apiVersion: v1
     sources:
@@ -40,7 +40,7 @@ entries:
     - email: unguiculus@gmail.com
       name: unguiculus
     urls:
-    - http://central.artipie.com/helm/ark-1.2.0.tgz
+    - ark-1.2.0.tgz
     appVersion: 0.9.1
     apiVersion: v1
     sources:


### PR DESCRIPTION
Part of #96 
Stopped using prefix in `PushChartSlice` because now urls are got by dynamically combining. For this purpose, `DownloadIndexSlice` was introduced. 
Bumped dependency of testcontainers from 1.14.3 to 1.15.1 to fix ITs failings.