### PR TITLE
Extract writer for index and class for parsed name validation

### DIFF
--- a/src/main/java/com/artipie/helm/Helm.java
+++ b/src/main/java/com/artipie/helm/Helm.java
@@ -257,8 +257,7 @@ public interface Helm {
                                     Asto.writeRemainedChartsAfterCopyIndex(pckgs, writer);
                                     entrs = false;
                                 }
-                                writer.write(line);
-                                writer.newLine();
+                                writer.writeLine(line, 0);
                             }
                             if (entrs) {
                                 Asto.writeRemainedChartsAfterCopyIndex(pckgs, writer);
@@ -348,13 +347,11 @@ public interface Helm {
         ) throws IOException {
             if (name != null && pckgs.containsKey(name)) {
                 for (final Pair<String, ChartYaml> pair : pckgs.get(name)) {
-                    writer.writeWithSpace("-", writer.indent() * 2);
-                    writer.newLine();
+                    writer.writeLine("-", 2);
                     final String str = new IndexYamlMapping(pair.getRight().fields()).toString();
                     for (final String entry : str.split("[\\n\\r]+")) {
                         // @checkstyle MagicNumberCheck (1 line)
-                        writer.writeWithSpace(entry, writer.indent() * 3);
-                        writer.newLine();
+                        writer.writeLine(entry, 3);
                     }
                 }
                 pckgs.remove(name);
@@ -374,18 +371,15 @@ public interface Helm {
             pckgs.forEach(
                 (chart, pairs) -> {
                     try {
-                        writer.writeWithSpace(String.format("%s:", chart), writer.indent());
-                        writer.newLine();
+                        writer.writeLine(String.format("%s:", chart), 1);
                         for (final Pair<String, ChartYaml> pair : pairs) {
-                            writer.writeWithSpace("- ", writer.indent() * 2);
-                            writer.newLine();
+                            writer.writeLine("- ", 2);
                             final String yaml;
                             yaml = new IndexYamlMapping(pair.getRight().fields()).toString();
                             final String[] lines = yaml.split("[\\n\\r]+");
                             for (final String line : lines) {
                                 // @checkstyle MagicNumberCheck (1 line)
-                                writer.writeWithSpace(line, writer.indent() * 3);
-                                writer.newLine();
+                                writer.writeLine(line, 3);
                             }
                         }
                     } catch (final IOException exc) {

--- a/src/main/java/com/artipie/helm/metadata/Index.java
+++ b/src/main/java/com/artipie/helm/metadata/Index.java
@@ -155,13 +155,11 @@ public interface Index {
                     if (!entrs) {
                         entrs = trimmed.equals(WithBreaks.ENTRS);
                     }
-                    if (entrs && trimmed.endsWith(":") && !trimmed.equals(WithBreaks.ENTRS)) {
+                    if (new ParsedChartName(line).valid()) {
                         if (name == null) {
                             indent = WithBreaks.lastPosOfSpaceInBegin(line);
                         }
-                        if (WithBreaks.lastPosOfSpaceInBegin(line) == indent
-                            && line.trim().charAt(0) != '-'
-                        ) {
+                        if (WithBreaks.lastPosOfSpaceInBegin(line) == indent) {
                             name = trimmed.replace(":", "");
                             vrns.put(name, new HashSet<>());
                         }

--- a/src/main/java/com/artipie/helm/metadata/ParsedChartName.java
+++ b/src/main/java/com/artipie/helm/metadata/ParsedChartName.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm.metadata;
+
+/**
+ * Encapsulates parsed chart name for validation.
+ * @since 0.3
+ */
+public final class ParsedChartName {
+    /**
+     * Entries.
+     */
+    private static final String ENTRS = "entries:";
+
+    /**
+     * Chart name.
+     */
+    private final String name;
+
+    /**
+     * Ctor.
+     * @param name Parsed from file with breaks chart name
+     */
+    public ParsedChartName(final String name) {
+        this.name = name.trim();
+    }
+
+    /**
+     * Validates chart name.
+     * @return True if parsed chart name is valid, false otherwise.
+     */
+    public boolean valid() {
+        return this.name.endsWith(":")
+            && !this.name.equals(ParsedChartName.ENTRS)
+            && this.name.charAt(0) != '-';
+    }
+}

--- a/src/main/java/com/artipie/helm/metadata/ParsedChartName.java
+++ b/src/main/java/com/artipie/helm/metadata/ParsedChartName.java
@@ -43,7 +43,7 @@ public final class ParsedChartName {
      * @param name Parsed from file with breaks chart name
      */
     public ParsedChartName(final String name) {
-        this.name = name.trim();
+        this.name = name;
     }
 
     /**
@@ -51,8 +51,9 @@ public final class ParsedChartName {
      * @return True if parsed chart name is valid, false otherwise.
      */
     public boolean valid() {
-        return this.name.endsWith(":")
-            && !this.name.equals(ParsedChartName.ENTRS)
-            && this.name.charAt(0) != '-';
+        final String trimmed = this.name.trim();
+        return trimmed.endsWith(":")
+            && !trimmed.equals(ParsedChartName.ENTRS)
+            && trimmed.charAt(0) != '-';
     }
 }

--- a/src/main/java/com/artipie/helm/metadata/YamlWriter.java
+++ b/src/main/java/com/artipie/helm/metadata/YamlWriter.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm.metadata;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Yaml writer with specified indent.
+ * @since 0.3
+ */
+public final class YamlWriter {
+    /**
+     * Required indent.
+     */
+    private final int indnt;
+
+    /**
+     * Buffered writer.
+     */
+    private final BufferedWriter writer;
+
+    /**
+     * Ctor.
+     * @param writer Writer
+     * @param indent Required indent in index file
+     */
+    public YamlWriter(final BufferedWriter writer, final int indent) {
+        this.writer = writer;
+        this.indnt = indent;
+    }
+
+    /**
+     * Obtains indent.
+     * @return Indent.
+     */
+    public int indent() {
+        return this.indnt;
+    }
+
+    /**
+     * Write data.
+     * @param data Data which should be written
+     * @throws IOException In case of error during writing.
+     */
+    public void write(final String data) throws IOException {
+        this.writer.write(data);
+    }
+
+    /**
+     * Write data with spaces at the beginning.
+     * @param data Data which should be written
+     * @param space Number of spaces at the beginning
+     * @throws IOException In case of error during writing.
+     */
+    public void writeWithSpace(final String data, final int space) throws IOException {
+        this.write(String.format("%s%s", StringUtils.repeat(' ', space), data));
+    }
+
+    /**
+     * Write new line.
+     * @throws IOException In case of error during writing.
+     */
+    public void newLine() throws IOException {
+        this.writer.newLine();
+    }
+}

--- a/src/main/java/com/artipie/helm/metadata/YamlWriter.java
+++ b/src/main/java/com/artipie/helm/metadata/YamlWriter.java
@@ -61,29 +61,19 @@ public final class YamlWriter {
     }
 
     /**
-     * Write data.
+     * Write data and a new line.
      * @param data Data which should be written
+     * @param xindendt How many times the minimum value of indent should be increased?
      * @throws IOException In case of error during writing.
      */
-    public void write(final String data) throws IOException {
-        this.writer.write(data);
-    }
-
-    /**
-     * Write data with spaces at the beginning.
-     * @param data Data which should be written
-     * @param space Number of spaces at the beginning
-     * @throws IOException In case of error during writing.
-     */
-    public void writeWithSpace(final String data, final int space) throws IOException {
-        this.write(String.format("%s%s", StringUtils.repeat(' ', space), data));
-    }
-
-    /**
-     * Write new line.
-     * @throws IOException In case of error during writing.
-     */
-    public void newLine() throws IOException {
+    public void writeLine(final String data, final int xindendt) throws IOException {
+        this.writer.write(
+            String.format(
+                "%s%s",
+                StringUtils.repeat(' ', xindendt * this.indnt),
+                data
+            )
+        );
         this.writer.newLine();
     }
 }

--- a/src/test/java/com/artipie/helm/HelmAstoAddTest.java
+++ b/src/test/java/com/artipie/helm/HelmAstoAddTest.java
@@ -42,6 +42,8 @@ import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test for {@link Helm.Asto#add(Collection)}.
@@ -60,13 +62,14 @@ final class HelmAstoAddTest {
         this.storage = new InMemoryStorage();
     }
 
-    @Test
-    void addInfoAboutNewVersionOfPackageAndNewPackage() {
+    @ParameterizedTest
+    @ValueSource(strings = {"index-one-ark.yaml", "index-one-ark-four-spaces.yaml"})
+    void addInfoAboutNewVersionOfPackageAndNewPackage(final String yaml) {
         final String tomcat = "tomcat-0.4.1.tgz";
         final String ark = "ark-1.2.0.tgz";
         this.saveToStorage(tomcat);
         this.saveToStorage(ark);
-        this.saveSourceIndex();
+        this.saveSourceIndex(yaml);
         this.addFilesToIndex(tomcat, ark);
         final IndexYamlMapping index = this.indexFromStrg();
         MatcherAssert.assertThat(
@@ -88,11 +91,12 @@ final class HelmAstoAddTest {
         );
     }
 
-    @Test
-    void addInfoAboutNewPackageAndContainsAllFields() {
+    @ParameterizedTest
+    @ValueSource(strings = {"index-one-ark.yaml", "index-one-ark-four-spaces.yaml"})
+    void addInfoAboutNewPackageAndContainsAllFields(final String yaml) {
         final String tomcat = "tomcat-0.4.1.tgz";
         this.saveToStorage(tomcat);
-        this.saveSourceIndex();
+        this.saveSourceIndex(yaml);
         this.addFilesToIndex(tomcat);
         final IndexYamlMapping index = this.indexFromStrg();
         MatcherAssert.assertThat(
@@ -109,11 +113,12 @@ final class HelmAstoAddTest {
         );
     }
 
-    @Test
-    void addInfoAboutNewVersion() {
+    @ParameterizedTest
+    @ValueSource(strings = {"index-one-ark.yaml", "index-one-ark-four-spaces.yaml"})
+    void addInfoAboutNewVersion(final String yaml) {
         final String ark = "ark-1.2.0.tgz";
         this.saveToStorage(ark);
-        this.saveSourceIndex();
+        this.saveSourceIndex(yaml);
         this.addFilesToIndex(ark);
         final IndexYamlMapping index = this.indexFromStrg();
         MatcherAssert.assertThat(
@@ -143,7 +148,7 @@ final class HelmAstoAddTest {
     void failsToAddInfoAboutExistedVersion() {
         final String ark = "ark-1.0.1.tgz";
         this.saveToStorage(ark);
-        this.saveSourceIndex();
+        this.saveSourceIndex("index-one-ark.yaml");
         final CompletionException exc = Assertions.assertThrows(
             CompletionException.class,
             () -> this.addFilesToIndex(ark)
@@ -175,10 +180,12 @@ final class HelmAstoAddTest {
         );
     }
 
-    private void saveSourceIndex() {
+    private void saveSourceIndex(final String name) {
         this.storage.save(
             IndexYaml.INDEX_YAML,
-            new Content.From(new TestResource("index/index-one-ark.yaml").asBytes())
+            new Content.From(
+                new TestResource(String.format("index/%s", name)).asBytes()
+            )
         ).join();
     }
 }

--- a/src/test/java/com/artipie/helm/metadata/ParsedChartNameTest.java
+++ b/src/test/java/com/artipie/helm/metadata/ParsedChartNameTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm.metadata;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link ParsedChartName}.
+ * @since 0.3
+ */
+final class ParsedChartNameTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"name:", " name_with_space_before:", " space_both: "})
+    void returnsValidForCorrectName(final String name) {
+        MatcherAssert.assertThat(
+            new ParsedChartName(name).valid(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"without_colon", " - starts_with_dash:", "entries:"})
+    void returnsNotValidForMalformedName(final String name) {
+        MatcherAssert.assertThat(
+            new ParsedChartName(name).valid(),
+            new IsEqual<>(false)
+        );
+    }
+}

--- a/src/test/resources/index/index-one-ark-four-spaces.yaml
+++ b/src/test/resources/index/index-one-ark-four-spaces.yaml
@@ -1,0 +1,22 @@
+generated: '2021-01-11T16:21:01.285921500+03:00'
+entries:
+    ark:
+        -
+            maintainers:
+            - email: d-caruso@hotmail.it
+              name: domcar
+            - email: unguiculus@gmail.com
+              name: unguiculus
+            appVersion: 0.8.2
+            urls:
+                - ark-1.0.1.tgz
+            apiVersion: v1
+            sources:
+                - https://github.com/heptio/ark
+            created: '2021-01-11T16:21:01.461400100+03:00'
+            digest: b2f648cc0e2caad299ad008ecbb1d7330f61cc44cef5020b9de265cdd457a0dd
+            name: ark
+            description: A Helm chart for ark
+            version: 1.0.1
+            home: https://heptio.com/products/#heptio-ark
+apiVersion: v1


### PR DESCRIPTION
Part of #117
Extracted yaml writer for index file, this file encapsulates required indents and instance of buffered writer. 
Also, extracted class for validation of parsed name.
Added test for case when there are four spaces in source index file. 