### PR TITLE
Extract `Charts` interface and `ChartsWriter`

### DIFF
--- a/src/main/java/com/artipie/helm/Charts.java
+++ b/src/main/java/com/artipie/helm/Charts.java
@@ -1,0 +1,140 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
+import com.artipie.helm.misc.DateTimeNow;
+import io.vertx.core.impl.ConcurrentHashSet;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Encapsulates logic for obtaining some meta info for charts from
+ * chart yaml file from tgz archive.
+ * @since 0.3
+ */
+interface Charts {
+    /**
+     * Obtains versions by chart names from storage for passed keys.
+     * @param charts Charts for which versions should be obtained
+     * @return Versions by chart names
+     */
+    CompletionStage<Map<String, Set<String>>> versionsFor(Collection<Key> charts);
+
+    /**
+     * Obtains versions and chart yaml content by chart names from storage for passed keys.
+     * @param charts Charts for which versions should be obtained
+     * @return Versions and chart yaml content by chart names
+     */
+    CompletionStage<Map<String, Set<Pair<String, ChartYaml>>>> versionsAndYamlFor(
+        Collection<Key> charts
+    );
+
+    /**
+     * Implementation of {@link Charts} for abstract storage.
+     * @since 0.3
+     */
+    final class Asto implements Charts {
+        /**
+         * Storage.
+         */
+        private final Storage storage;
+
+        /**
+         * Ctor.
+         * @param storage Storage
+         */
+        Asto(final Storage storage) {
+            this.storage = storage;
+        }
+
+        @Override
+        public CompletionStage<Map<String, Set<String>>> versionsFor(final Collection<Key> charts) {
+            final Map<String, Set<String>> pckgs = new ConcurrentHashMap<>();
+            return CompletableFuture.allOf(
+                charts.stream().map(
+                    key -> this.storage.value(key)
+                        .thenApply(PublisherAs::new)
+                        .thenCompose(PublisherAs::bytes)
+                        .thenApply(TgzArchive::new)
+                        .thenAccept(
+                            tgz -> {
+                                final ChartYaml chart = tgz.chartYaml();
+                                pckgs.putIfAbsent(chart.name(), new HashSet<>());
+                                pckgs.get(chart.name()).add(chart.version());
+                            }
+                        )
+                ).toArray(CompletableFuture[]::new)
+            ).thenApply(noth -> pckgs);
+        }
+
+        @Override
+        public CompletionStage<Map<String, Set<Pair<String, ChartYaml>>>> versionsAndYamlFor(
+            final Collection<Key> charts
+        ) {
+            final Map<String, Set<Pair<String, ChartYaml>>> pckgs = new ConcurrentHashMap<>();
+            return CompletableFuture.allOf(
+                charts.stream().map(
+                    key -> this.storage.value(key)
+                        .thenApply(PublisherAs::new)
+                        .thenCompose(PublisherAs::bytes)
+                        .thenApply(TgzArchive::new)
+                        .thenAccept(tgz -> Charts.Asto.addChartFromTgzToPackages(tgz, pckgs))
+                ).toArray(CompletableFuture[]::new)
+            ).thenApply(noth -> pckgs);
+        }
+
+        /**
+         * Add chart from tgz archive to packages collection.
+         * @param tgz Tgz archive with chart yaml file
+         * @param pckgs Packages collection which contains info about passed packages for
+         *  adding to index file. There is a version and chart yaml for each package.
+         */
+        private static void addChartFromTgzToPackages(
+            final TgzArchive tgz,
+            final Map<String, Set<Pair<String, ChartYaml>>> pckgs
+        ) {
+            final Map<String, Object> fields = new HashMap<>(tgz.chartYaml().fields());
+            fields.putAll(tgz.metadata(Optional.empty()));
+            fields.put("created", new DateTimeNow().asString());
+            final ChartYaml chart = new ChartYaml(fields);
+            final String name = chart.name();
+            pckgs.putIfAbsent(name, new ConcurrentHashSet<>());
+            pckgs.get(name).add(
+                new ImmutablePair<>(chart.version(), chart)
+            );
+        }
+    }
+}

--- a/src/main/java/com/artipie/helm/ChartsWriter.java
+++ b/src/main/java/com/artipie/helm/ChartsWriter.java
@@ -1,0 +1,265 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm;
+
+import com.artipie.asto.Storage;
+import com.artipie.helm.metadata.Index;
+import com.artipie.helm.metadata.IndexYaml;
+import com.artipie.helm.metadata.IndexYamlMapping;
+import com.artipie.helm.metadata.ParsedChartName;
+import com.artipie.helm.metadata.YamlWriter;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Writer of index file which combines source existed index file and add
+ * information about passed charts.
+ * @since 0.3
+ * @checkstyle CyclomaticComplexityCheck (500 lines)
+ * @checkstyle ExecutableStatementCountCheck (500 lines)
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class ChartsWriter {
+    /**
+     * Versions.
+     */
+    static final String VRSNS = "version:";
+
+    /**
+     * Entries.
+     */
+    static final String ENTRS = "entries:";
+
+    /**
+     * Storage.
+     */
+    private final Storage storage;
+
+    /**
+     * Ctor.
+     * @param storage Storage
+     */
+    ChartsWriter(final Storage storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * Add info about charts to index. If index contains a chart with the same
+     * version, the exception will be generated. It has the next implementation.
+     * Read index file line by line. If we are in the `entries:` section, we will check
+     * whether the line is a name of chart (e.g. line has correct indent and ends
+     * with colon). It copy source index file line by line and if the line with
+     * version is met, the existence of this version in packages would be checked
+     * to avoid adding existed package. If the new name of chart is met, it will
+     * write remained versions from packages. When we read next line after end of
+     * `entries:` section from source index, we write info about remained charts
+     * in packages.
+     * @param source Path to temporary file with index
+     * @param out Path to temporary file in which new index would be written
+     * @param pckgs Packages collection which contains info about passed packages for
+     *  adding to index file. There is a version and chart yaml for each package.
+     * @return Result of completion
+     */
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    public CompletionStage<Void> addChartsToIndex(
+        final Path source,
+        final Path out,
+        final Map<String, Set<Pair<String, ChartYaml>>> pckgs
+    ) {
+        return this.storage.exists(IndexYaml.INDEX_YAML)
+            .thenCompose(this::versionsByPckgs)
+            .thenCompose(
+                vrsns -> {
+                    try (
+                        BufferedReader br = new BufferedReader(
+                            new InputStreamReader(Files.newInputStream(source))
+                        );
+                        BufferedWriter bufw = new BufferedWriter(
+                            new OutputStreamWriter(Files.newOutputStream(out))
+                        )
+                    ) {
+                        String line;
+                        boolean entrs = false;
+                        String name = null;
+                        YamlWriter writer = new YamlWriter(bufw, 2);
+                        while ((line = br.readLine()) != null) {
+                            final String trimmed = line.trim();
+                            if (!entrs) {
+                                entrs = trimmed.equals(ChartsWriter.ENTRS);
+                            }
+                            if (entrs && new ParsedChartName(line).valid()) {
+                                if (name == null) {
+                                    writer = new YamlWriter(
+                                        bufw, ChartsWriter.lastPosOfSpaceInBegin(line)
+                                    );
+                                }
+                                if (ChartsWriter.lastPosOfSpaceInBegin(line) == writer.indent()) {
+                                    ChartsWriter.writeRemainedVersionsOfChart(name, pckgs, writer);
+                                    name = trimmed.replace(":", "");
+                                }
+                            }
+                            if (entrs) {
+                                ChartsWriter.throwIfVersionExists(trimmed, name, pckgs);
+                            }
+                            if (entrs && name != null
+                                && ChartsWriter.lastPosOfSpaceInBegin(line) == 0
+                            ) {
+                                ChartsWriter.writeRemainedVersionsOfChart(name, pckgs, writer);
+                                ChartsWriter.writeRemainedChartsAfterCopyIndex(pckgs, writer);
+                                entrs = false;
+                            }
+                            writer.writeLine(line, 0);
+                        }
+                        if (entrs) {
+                            ChartsWriter.writeRemainedChartsAfterCopyIndex(pckgs, writer);
+                        }
+                    } catch (final IOException exc) {
+                        throw new UncheckedIOException(exc);
+                    }
+                    return CompletableFuture.allOf();
+                }
+            );
+    }
+
+    /**
+     * Obtains versions by packages from source index file or empty collection in case of
+     * absence source index file.
+     * @param exists Does source index file exist?
+     * @return Versions by packages.
+     */
+    private CompletionStage<Map<String, Set<String>>> versionsByPckgs(final boolean exists) {
+        final CompletionStage<Map<String, Set<String>>> res;
+        if (exists) {
+            res = new Index.WithBreaks(this.storage).versionsByPackages();
+        } else {
+            res = CompletableFuture.completedFuture(new HashMap<>());
+        }
+        return res;
+    }
+
+    /**
+     * Generates an exception if version of chart which contains in trimmed
+     * line exists in packages.
+     * @param trimmed Trimmed line from index file
+     * @param name Name of chart
+     * @param pckgs Packages collection which contains info about passed packages for
+     *  adding to index file. There is a version and chart yaml for each package.
+     */
+    private static void throwIfVersionExists(
+        final String trimmed,
+        final String name,
+        final Map<String, Set<Pair<String, ChartYaml>>> pckgs
+    ) {
+        if (trimmed.startsWith(ChartsWriter.VRSNS)) {
+            final String vers = trimmed.replace(ChartsWriter.VRSNS, "").trim();
+            if (pckgs.containsKey(name) && pckgs.get(name).stream().anyMatch(
+                pair -> pair.getLeft().equals(vers)
+            )) {
+                throw new IllegalStateException(
+                    String.format("Failed to write to index `%s` with version `%s`", name, vers)
+                );
+            }
+        }
+    }
+
+    /**
+     * Write remained versions of passed chart in collection in case of their existence.
+     * @param name Chart name for which remained versions are checked
+     * @param pckgs Packages collection which contains info about passed packages for
+     *  adding to index file. There is a version and chart yaml for each package.
+     * @param writer Yaml writer
+     * @throws IOException In case of exception during writing
+     */
+    private static void writeRemainedVersionsOfChart(
+        final String name,
+        final Map<String, Set<Pair<String, ChartYaml>>> pckgs,
+        final YamlWriter writer
+    ) throws IOException {
+        if (name != null && pckgs.containsKey(name)) {
+            for (final Pair<String, ChartYaml> pair : pckgs.get(name)) {
+                writer.writeLine("-", 2);
+                final String str = new IndexYamlMapping(pair.getRight().fields()).toString();
+                for (final String entry : str.split("[\\n\\r]+")) {
+                    // @checkstyle MagicNumberCheck (1 line)
+                    writer.writeLine(entry, 3);
+                }
+            }
+            pckgs.remove(name);
+        }
+    }
+
+    /**
+     * Write remained versions for all charts in collection in case of their existence.
+     * @param pckgs Packages collection which contains info about passed packages for
+     *  adding to index file. There is a version and chart yaml for each package.
+     * @param writer Yaml writer
+     */
+    private static void writeRemainedChartsAfterCopyIndex(
+        final Map<String, Set<Pair<String, ChartYaml>>> pckgs,
+        final YamlWriter writer
+    ) {
+        pckgs.forEach(
+            (chart, pairs) -> {
+                try {
+                    writer.writeLine(String.format("%s:", chart), 1);
+                    for (final Pair<String, ChartYaml> pair : pairs) {
+                        writer.writeLine("- ", 2);
+                        final String yaml;
+                        yaml = new IndexYamlMapping(pair.getRight().fields()).toString();
+                        final String[] lines = yaml.split("[\\n\\r]+");
+                        for (final String line : lines) {
+                            // @checkstyle MagicNumberCheck (1 line)
+                            writer.writeLine(line, 3);
+                        }
+                    }
+                } catch (final IOException exc) {
+                    throw  new UncheckedIOException(exc);
+                }
+            }
+        );
+        pckgs.clear();
+    }
+
+    /**
+     * Obtains last position of space from beginning before meeting any character.
+     * @param line Text line
+     * @return Last position of space from beginning before meeting any character.
+     */
+    private static int lastPosOfSpaceInBegin(final String line) {
+        return line.length() - line.replaceAll("^\\s*", "").length();
+    }
+}

--- a/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
+++ b/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
+import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link Charts.Asto}.
  * @since 0.3
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class ChartsAstoVersionsForTest {
     @Test
@@ -57,10 +59,12 @@ final class ChartsAstoVersionsForTest {
                         .collect(Collectors.toList())
                 ).toCompletableFuture().join(),
             new IsEqual<>(
-                new MapOf<>(
-                    new MapEntry<>("tomcat", new SetOf<>("0.4.1")),
-                    new MapEntry<>("ark", new SetOf<>("1.2.0", "1.0.1"))
-                )
+                new Unchecked<>(
+                    () -> new MapOf<>(
+                        new MapEntry<>("tomcat", new SetOf<>("0.4.1")),
+                        new MapEntry<>("ark", new SetOf<>("1.2.0", "1.0.1"))
+                    )
+                ).value()
             )
         );
     }

--- a/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
+++ b/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
@@ -59,12 +59,16 @@ final class ChartsAstoVersionsForTest {
                         .collect(Collectors.toList())
                 ).toCompletableFuture().join(),
             new IsEqual<>(
-                new Unchecked<>(
-                    () -> new MapOf<>(
-                        new MapEntry<>("tomcat", new SetOf<>("0.4.1")),
-                        new MapEntry<>("ark", new SetOf<>("1.2.0", "1.0.1"))
+                new MapOf<>(
+                    new MapEntry<>(
+                        "tomcat",
+                        new Unchecked<>(() -> new SetOf<>("0.4.1")).value()
+                    ),
+                    new MapEntry<>(
+                        "ark",
+                        new Unchecked<>(() -> new SetOf<>("1.2.0", "1.0.1")).value()
                     )
-                ).value()
+                )
             )
         );
     }

--- a/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
+++ b/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.test.TestResource;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.cactoos.set.SetOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link Charts.Asto}.
+ * @since 0.3
+ */
+final class ChartsAstoVersionsForTest {
+    @Test
+    void getsVersionsForPassedCharts() {
+        final Storage storage = new InMemoryStorage();
+        final String arkone = "ark-1.0.1.tgz";
+        final String arktwo = "ark-1.2.0.tgz";
+        final String tomcat = "tomcat-0.4.1.tgz";
+        Stream.of(arkone, arktwo, tomcat)
+            .forEach(tgz -> new TestResource(tgz).saveTo(storage));
+        MatcherAssert.assertThat(
+            new Charts.Asto(storage)
+                .versionsFor(
+                    Stream.of(arkone, arktwo, tomcat)
+                        .map(Key.From::new)
+                        .collect(Collectors.toList())
+                ).toCompletableFuture().join(),
+            new IsEqual<>(
+                new MapOf<>(
+                    new MapEntry<>("tomcat", new SetOf<>("0.4.1")),
+                    new MapEntry<>("ark", new SetOf<>("1.2.0", "1.0.1"))
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
+++ b/src/test/java/com/artipie/helm/ChartsAstoVersionsForTest.java
@@ -27,11 +27,11 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.test.TestResource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.cactoos.map.MapEntry;
-import org.cactoos.map.MapOf;
-import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for {@link Charts.Asto}.
  * @since 0.3
- * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 final class ChartsAstoVersionsForTest {
     @Test
@@ -51,6 +50,9 @@ final class ChartsAstoVersionsForTest {
         final String tomcat = "tomcat-0.4.1.tgz";
         Stream.of(arkone, arktwo, tomcat)
             .forEach(tgz -> new TestResource(tgz).saveTo(storage));
+        final Map<String, Set<String>> expected = new HashMap<>();
+        expected.put("tomcat", new SetOf<String>("0.4.1"));
+        expected.put("ark", new SetOf<String>("1.2.0", "1.0.1"));
         MatcherAssert.assertThat(
             new Charts.Asto(storage)
                 .versionsFor(
@@ -58,18 +60,7 @@ final class ChartsAstoVersionsForTest {
                         .map(Key.From::new)
                         .collect(Collectors.toList())
                 ).toCompletableFuture().join(),
-            new IsEqual<>(
-                new MapOf<>(
-                    new MapEntry<>(
-                        "tomcat",
-                        new Unchecked<>(() -> new SetOf<>("0.4.1")).value()
-                    ),
-                    new MapEntry<>(
-                        "ark",
-                        new Unchecked<>(() -> new SetOf<>("1.2.0", "1.0.1")).value()
-                    )
-                )
-            )
+            new IsEqual<>(expected)
         );
     }
 }


### PR DESCRIPTION
Part of #117 
Extracted `Charts` interface for obtaining info about passed charts as keys from storage.
Extracted `ChartsWriter` for combining info from chart yaml files from storage by passed keys and content of existed index file.
Next I'll add test for `Charts.Asto#versionsAndYamlFor` and for `ChartsWriter`