### PR TITLE
Add prefix for `remove` operation

### DIFF
--- a/src/main/java/com/artipie/helm/AddWriter.java
+++ b/src/main/java/com/artipie/helm/AddWriter.java
@@ -23,6 +23,7 @@
  */
 package com.artipie.helm;
 
+import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.helm.metadata.Index;
 import com.artipie.helm.metadata.IndexYamlMapping;
@@ -116,7 +117,7 @@ interface AddWriter {
             final Map<String, Set<Pair<String, ChartYaml>>> pckgs
         ) {
             return new Index.WithBreaks(this.storage)
-                .versionsByPackages()
+                .versionsByPackages(new Key.From(source.getFileName().toString()))
                 .thenCompose(
                     vrsns -> {
                         try (

--- a/src/main/java/com/artipie/helm/metadata/Index.java
+++ b/src/main/java/com/artipie/helm/metadata/Index.java
@@ -52,9 +52,10 @@ import java.util.concurrent.CompletionStage;
 public interface Index {
     /**
      * Obtains versions for packages which exist in the index file.
+     * @param idxpath Path to index file
      * @return Map where key is a package name, value is represented versions.
      */
-    CompletionStage<Map<String, Set<String>>> versionsByPackages();
+    CompletionStage<Map<String, Set<String>>> versionsByPackages(Key idxpath);
 
     /**
      * Reader of `index.yaml` which contains break lines.
@@ -94,8 +95,8 @@ public interface Index {
         }
 
         @Override
-        public CompletionStage<Map<String, Set<String>>> versionsByPackages() {
-            return this.storage.exists(IndexYaml.INDEX_YAML)
+        public CompletionStage<Map<String, Set<String>>> versionsByPackages(final Key idx) {
+            return this.storage.exists(idx)
                 .thenCompose(
                     exists -> {
                         CompletionStage<Map<String, Set<String>>> res;
@@ -104,7 +105,7 @@ public interface Index {
                                 final String prefix = "index-";
                                 final Path tmp = Files.createTempDirectory(prefix);
                                 final Path file = Files.createTempFile(tmp, prefix, ".yaml");
-                                res = this.storage.value(IndexYaml.INDEX_YAML)
+                                res = this.storage.value(idx)
                                     .thenCompose(
                                         cont -> new FileStorage(tmp).save(
                                             new Key.From(file.getFileName().toString()), cont

--- a/src/test/java/com/artipie/helm/RemoveWriterAstoTest.java
+++ b/src/test/java/com/artipie/helm/RemoveWriterAstoTest.java
@@ -41,9 +41,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -144,6 +147,22 @@ final class RemoveWriterAstoTest {
         MatcherAssert.assertThat(
             this.indexFromStrg().entries().isEmpty(),
             new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    void failsToDeleteAbsentInIndexChart() {
+        final String chart = "tomcat-0.4.1.tgz";
+        new TestResource("index/index-one-ark.yaml")
+            .saveTo(this.storage, new Key.From(this.source.getFileName().toString()));
+        new TestResource(chart).saveTo(this.storage);
+        final Throwable thr = Assertions.assertThrows(
+            CompletionException.class,
+            () -> this.delete(chart)
+        );
+        MatcherAssert.assertThat(
+            thr.getCause(),
+            new IsInstanceOf(IllegalStateException.class)
         );
     }
 


### PR DESCRIPTION
Part of #139 
Added prefix for `remove` operation. Added tests for verifying deletion for nested archives.
Removed `failsToDeleteAbsentChartIfTgzIsAbsent()` tests from `RemoveWriterAstoTest` as `RemoveWriterAsto` doesn't work now with archives from storage and accepts now `Map<String, Set<String>>`. This negative scenario is covered in `HelmAstoDeleteTest`
