### PR TITLE
Add method in `AddWriter` for adding charts trustfully

### DIFF
--- a/src/main/java/com/artipie/helm/ChartYaml.java
+++ b/src/main/java/com/artipie/helm/ChartYaml.java
@@ -25,6 +25,7 @@ package com.artipie.helm;
 
 import java.util.List;
 import java.util.Map;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -86,5 +87,13 @@ public final class ChartYaml {
      */
     public List<String> urls() {
         return (List<String>) this.mapping.get("urls");
+    }
+
+    @Override
+    public String toString() {
+        final DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        return new Yaml(options).dump(this.mapping);
     }
 }


### PR DESCRIPTION
Part of #105 
Added method in `AddWriter` for adding info about charts to index trustfully. It means that existed index does not check somehow and info about all passed charts is added to a new index. Info doesn't check somehow in existed index file because anyway it is necessary to extract chart info from archive