### PR TITLE
Add IT for delete chart operation, fix path

### DIFF
--- a/src/test/java/com/artipie/helm/HelmSliceIT.java
+++ b/src/test/java/com/artipie/helm/HelmSliceIT.java
@@ -33,6 +33,7 @@ import com.artipie.http.auth.JoinedPermissions;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.misc.RandomFreePort;
 import com.artipie.http.rs.RsStatus;
+import com.artipie.http.slice.LoggingSlice;
 import com.artipie.vertx.VertxSliceServer;
 import com.google.common.io.ByteStreams;
 import io.vertx.reactivex.core.Vertx;
@@ -192,20 +193,24 @@ final class HelmSliceIT {
         Testcontainers.exposeHostPorts(this.port);
         if (anonymous) {
             this.server = new VertxSliceServer(
-                HelmSliceIT.VERTX, new HelmSlice(this.storage, this.url), this.port
+                HelmSliceIT.VERTX,
+                new LoggingSlice(new HelmSlice(this.storage, this.url)),
+                this.port
             );
         } else {
             this.server = new VertxSliceServer(
                 HelmSliceIT.VERTX,
-                new HelmSlice(
-                    this.storage,
-                    this.url,
-                    new JoinedPermissions(
-                        new Permissions.Single(HelmSliceIT.USER, "download"),
-                        new Permissions.Single(HelmSliceIT.USER, "upload")
-                    ),
-                    new Authentication.Single(
-                        HelmSliceIT.USER, HelmSliceIT.PSWD
+                new LoggingSlice(
+                    new HelmSlice(
+                        this.storage,
+                        this.url,
+                        new JoinedPermissions(
+                            new Permissions.Single(HelmSliceIT.USER, "download"),
+                            new Permissions.Single(HelmSliceIT.USER, "upload")
+                        ),
+                        new Authentication.Single(
+                            HelmSliceIT.USER, HelmSliceIT.PSWD
+                        )
                     )
                 ),
                 this.port

--- a/src/test/java/com/artipie/helm/http/DeleteChartSliceTest.java
+++ b/src/test/java/com/artipie/helm/http/DeleteChartSliceTest.java
@@ -62,7 +62,7 @@ final class DeleteChartSliceTest {
 
     @ParameterizedTest
     @ValueSource(
-        strings = {"", "/chart?noname=no", "/chart?version=1.0.2", "/wrongPath?name=any"}
+        strings = {"", "/charts", "/charts/", "/charts/name/1.3.2/extra", "/wrong/name/0.1.1"}
         )
     void returnBadRequest(final String rqline) {
         MatcherAssert.assertThat(
@@ -84,7 +84,7 @@ final class DeleteChartSliceTest {
         MatcherAssert.assertThat(
             "Response status is not 200",
             new DeleteChartSlice(this.storage).response(
-                new RequestLine(RqMethod.DELETE, "/chart?name=ark").toString(),
+                new RequestLine(RqMethod.DELETE, "/charts/ark").toString(),
                 Headers.EMPTY,
                 Content.EMPTY
             ),
@@ -115,7 +115,7 @@ final class DeleteChartSliceTest {
         MatcherAssert.assertThat(
             "Response status is not 200",
             new DeleteChartSlice(this.storage).response(
-                new RequestLine(RqMethod.DELETE, "/chart?name=ark&version=1.0.1").toString(),
+                new RequestLine(RqMethod.DELETE, "/charts/ark/1.0.1").toString(),
                 Headers.EMPTY,
                 Content.EMPTY
             ),
@@ -140,7 +140,7 @@ final class DeleteChartSliceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"/chart?name=not-exist", "/chart?name=ark&version=0.0.0"})
+    @ValueSource(strings = {"/charts/not-exist", "/charts/ark/0.0.0"})
     void failsToDeleteByNotExisted(final String rqline) {
         Stream.of("index.yaml", "ark-1.0.1.tgz", "ark-1.2.0.tgz", "tomcat-0.4.1.tgz")
             .forEach(source -> new TestResource(source).saveTo(this.storage));

--- a/src/test/java/com/artipie/helm/http/HelmDeleteIT.java
+++ b/src/test/java/com/artipie/helm/http/HelmDeleteIT.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.helm.http;
+
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.asto.test.TestResource;
+import com.artipie.helm.test.ContentOfIndex;
+import com.artipie.http.misc.RandomFreePort;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.slice.LoggingSlice;
+import com.artipie.vertx.VertxSliceServer;
+import io.vertx.reactivex.core.Vertx;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * IT for remove operation.
+ * @since 0.3
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+final class HelmDeleteIT {
+    /**
+     * Vert instance.
+     */
+    private static final Vertx VERTX = Vertx.vertx();
+
+    /**
+     * The server.
+     */
+    private VertxSliceServer server;
+
+    /**
+     * Port.
+     */
+    private int port;
+
+    /**
+     * URL connection.
+     */
+    private HttpURLConnection conn;
+
+    /**
+     * Storage.
+     */
+    private Storage storage;
+
+    @BeforeEach
+    void setUp() {
+        this.storage = new InMemoryStorage();
+        this.port = new RandomFreePort().get();
+        this.server = new VertxSliceServer(
+            HelmDeleteIT.VERTX,
+            new LoggingSlice(
+                new HelmSlice(this.storage, String.format("http://localhost:%d", this.port))
+            ),
+            this.port
+        );
+        this.server.start();
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        HelmDeleteIT.VERTX.close();
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.conn.disconnect();
+        this.server.close();
+    }
+
+    @Test
+    void chartShould() throws Exception {
+        Stream.of("index.yaml", "ark-1.0.1.tgz", "ark-1.2.0.tgz", "tomcat-0.4.1.tgz")
+            .forEach(source -> new TestResource(source).saveTo(this.storage));
+        this.conn = (HttpURLConnection) new URL(
+            String.format("http://localhost:%d/charts/tomcat", this.port)
+        ).openConnection();
+        this.conn.setRequestMethod(RqMethod.DELETE.value());
+        this.conn.setDoOutput(true);
+        MatcherAssert.assertThat(
+            "Response status is not 200",
+            this.conn.getResponseCode(),
+            new IsEqual<>(Integer.parseInt(RsStatus.OK.code()))
+        );
+        MatcherAssert.assertThat(
+            "Archive was not deleted",
+            this.storage.exists(new Key.From("tomcat-0.4.1.tgz")).join(),
+            new IsEqual<>(false)
+        );
+        MatcherAssert.assertThat(
+            "Index was not updated",
+            new ContentOfIndex(this.storage).index().byChart("tomcat").isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+}


### PR DESCRIPTION
Closes #106 
Added IT for `DeleteChartSlice`. Changed route path according to [this](https://github.com/helm/chartmuseum#chart-manipulation)