### PR TITLE
Enhance `TgzArchive` test, exclude `com.fasterxml.jackson.core`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@ SOFTWARE.
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
       <version>1.2.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.reactivestreams</groupId>

--- a/src/main/java/com/artipie/helm/Charts.java
+++ b/src/main/java/com/artipie/helm/Charts.java
@@ -27,7 +27,6 @@ import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.ext.PublisherAs;
 import com.artipie.helm.misc.DateTimeNow;
-import io.vertx.core.impl.ConcurrentHashSet;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -131,7 +130,7 @@ interface Charts {
             fields.put("created", new DateTimeNow().asString());
             final ChartYaml chart = new ChartYaml(fields);
             final String name = chart.name();
-            pckgs.putIfAbsent(name, new ConcurrentHashSet<>());
+            pckgs.putIfAbsent(name, ConcurrentHashMap.newKeySet());
             pckgs.get(name).add(
                 new ImmutablePair<>(chart.version(), chart)
             );

--- a/src/test/java/com/artipie/helm/http/HelmDeleteIT.java
+++ b/src/test/java/com/artipie/helm/http/HelmDeleteIT.java
@@ -102,7 +102,7 @@ final class HelmDeleteIT {
     }
 
     @Test
-    void chartShould() throws Exception {
+    void chartShouldBeDeleted() throws Exception {
         Stream.of("index.yaml", "ark-1.0.1.tgz", "ark-1.2.0.tgz", "tomcat-0.4.1.tgz")
             .forEach(source -> new TestResource(source).saveTo(this.storage));
         this.conn = (HttpURLConnection) new URL(


### PR DESCRIPTION
Closes #29 
Part of #180 
Eliminated using of  classes from `io.vertx.core.impl` by refactoring test and excluded `com.fasterxml.jackson.core`