### PR TITLE
Use tokenizer instead of copying index for `delete`

### DIFF
--- a/src/main/java/com/artipie/helm/AddWriter.java
+++ b/src/main/java/com/artipie/helm/AddWriter.java
@@ -132,7 +132,6 @@ interface AddWriter {
          * in packages.
          */
         @Override
-        @SuppressWarnings("PMD.AssignmentInOperand")
         public CompletionStage<Void> add(
             final Key source,
             final Path out,

--- a/src/main/java/com/artipie/helm/metadata/Index.java
+++ b/src/main/java/com/artipie/helm/metadata/Index.java
@@ -40,10 +40,6 @@ import java.util.concurrent.CompletionStage;
 /**
  * Reader of `index.yaml` file which does not read the entire file into memory.
  * @since 0.3
- * @todo #112:90min Replace parser with reactive version to avoid copying index
- *  file to temp storage. This parser should be replaced with converter from Publisher#ByteBuffer
- *  to another Publisher#ByteBuffer which is splitted by breaks (based on implementation
- *  of org.reactivestreams.Processor)
  */
 public interface Index {
     /**

--- a/src/test/resources/index/index-four-spaces.yaml
+++ b/src/test/resources/index/index-four-spaces.yaml
@@ -1,63 +1,63 @@
 generated: '2021-01-11T16:21:01.285921500+03:00'
 entries:
-  tomcat:
-    -
-      maintainers:
+    tomcat:
         -
-          email: ybiran@ananware.systems
-          name: yahavb
-      urls:
-        - tomcat-0.4.1.tgz
-      appVersion: '7.0'
-      apiVersion: v1
-      created: '2021-01-11T16:21:01.376598500+03:00'
-      digest: d8dcdcfcb512595960979cbd44728a8d8b0194c88335d0f84543e84b3939b8ce
-      icon: 'http://tomcat.apache.org/res/images/tomcat.png'
-      name: tomcat
-      description: >-
-        Deploy a basic tomcat application server with sidecar as web
-        archive container
-      version: 0.4.1
-      home: 'https://github.com/yahavb'
-  ark:
-    -
-      maintainers:
+            maintainers:
+                -
+                    email: ybiran@ananware.systems
+                    name: yahavb
+            urls:
+                - tomcat-0.4.1.tgz
+            appVersion: '7.0'
+            apiVersion: v1
+            created: '2021-01-11T16:21:01.376598500+03:00'
+            digest: d8dcdcfcb512595960979cbd44728a8d8b0194c88335d0f84543e84b3939b8ce
+            icon: 'http://tomcat.apache.org/res/images/tomcat.png'
+            name: tomcat
+            description: >-
+                Deploy a basic tomcat application server with sidecar as web
+                archive container
+            version: 0.4.1
+            home: 'https://github.com/yahavb'
+    ark:
         -
-          email: d-caruso@hotmail.it
-          name: domcar
+            maintainers:
+                -
+                    email: d-caruso@hotmail.it
+                    name: domcar
+                -
+                    email: unguiculus@gmail.com
+                    name: unguiculus
+            urls:
+                - ark-1.0.1.tgz
+            appVersion: 0.8.2
+            apiVersion: v1
+            sources:
+                - 'https://github.com/heptio/ark'
+            created: '2021-01-11T16:21:01.461400100+03:00'
+            digest: b2f648cc0e2caad299ad008ecbb1d7330f61cc44cef5020b9de265cdd457a0dd
+            name: ark
+            description: A Helm chart for ark
+            version: 1.0.1
+            home: 'https://heptio.com/products/#heptio-ark'
         -
-          email: unguiculus@gmail.com
-          name: unguiculus
-      urls:
-        - ark-1.0.1.tgz
-      appVersion: 0.8.2
-      apiVersion: v1
-      sources:
-        - 'https://github.com/heptio/ark'
-      created: '2021-01-11T16:21:01.461400100+03:00'
-      digest: b2f648cc0e2caad299ad008ecbb1d7330f61cc44cef5020b9de265cdd457a0dd
-      name: ark
-      description: A Helm chart for ark
-      version: 1.0.1
-      home: 'https://heptio.com/products/#heptio-ark'
-    -
-      maintainers:
-        -
-          email: d-caruso@hotmail.it
-          name: domcar
-        -
-          email: unguiculus@gmail.com
-          name: unguiculus
-      urls:
-        - ark-1.2.0.tgz
-      appVersion: 0.9.1
-      apiVersion: v1
-      sources:
-        - 'https://github.com/heptio/ark'
-      created: '2021-01-11T16:21:01.477022600+03:00'
-      digest: 4ae713c5afe86b9699a317f2b8a5847a9cd507038d96f12409b64e5c00319a8a
-      name: ark
-      description: A Helm chart for ark
-      version: 1.2.0
-      home: 'https://heptio.com/products/#heptio-ark'
+            maintainers:
+                -
+                    email: d-caruso@hotmail.it
+                    name: domcar
+                -
+                    email: unguiculus@gmail.com
+                    name: unguiculus
+            urls:
+                - ark-1.2.0.tgz
+            appVersion: 0.9.1
+            apiVersion: v1
+            sources:
+                - 'https://github.com/heptio/ark'
+            created: '2021-01-11T16:21:01.477022600+03:00'
+            digest: 4ae713c5afe86b9699a317f2b8a5847a9cd507038d96f12409b64e5c00319a8a
+            name: ark
+            description: A Helm chart for ark
+            version: 1.2.0
+            home: 'https://heptio.com/products/#heptio-ark'
 apiVersion: v1


### PR DESCRIPTION
Closes #113 
Use reactive tokenizer for `remove` instead of copying index file in temporary file. Now it reads line by line from source file and write a new index to a temporary file which at the end replaces source index file.
Also fix test file which should contain four spaces instead of two